### PR TITLE
Deploy to Github Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,56 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: 
+      - 'cardsboard' # default branch
+      - 'deploy-static' # TODO: remove it before merging
+
+jobs:
+  build_site:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this repository
+        uses: actions/checkout@v5
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '25'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: build
+        env:
+          BASE_PATH: '/${{ github.event.repository.name }}'
+        run: |
+          pnpm run build
+      
+      - name: Upload Artifacts
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: 'build/'
+
+  deploy:
+    needs: build_site
+    runs-on: ubuntu-latest
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,9 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: 
-      - 'cardsboard' # default branch
-      - 'deploy-static' # TODO: remove it before merging
+    branches: 'cardsboard' # default branch
 
 jobs:
   build_site:

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,5 @@ storybook-static
 # Gemini
 .gemini
 .kilocode/rules/SHADCN.md
-.github
 /tasks
 

--- a/src/routes/+layout.js
+++ b/src/routes/+layout.js
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -4,10 +4,17 @@ import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	// Consult https://svelte.dev/docs/kit/integrations
-	// for more information about preprocessors
 	preprocess: [vitePreprocess(), mdsvex()],
-	kit: { adapter: adapter() },
+	// The fallback: '404.html' and the path: { base: ... process.env.BASE_PATH } are needed to host
+	// the site on GitHub Pages. Change them if it is going to be hosted somewhere else.
+	kit: {
+		adapter: adapter({
+			fallback: '404.html'
+		}),
+		paths: {
+			base: process.argv.includes('dev') ? '' : process.env.BASE_PATH
+		}
+	},
 	extensions: ['.svelte', '.svx'],
 	vitePlugin: {
 		inspector: {


### PR DESCRIPTION
Je früher die Stakeholders das Ergebnis der Entwicklung sehen können, desto früher bekommen wir Rückmeldung. Von daher habe ich es auf Github Pages deployen lassen, sodass wir einfach mit ihnen Links teilen können

https://edufeed-org.github.io/kanban-editor/
https://edufeed-org.github.io/kanban-editor/cardsboard

