### PR TITLE
improve oer-finder-plugin setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,21 +89,19 @@
   ],
   "pnpm": {
     "onlyBuiltDependencies": [
-      "esbuild",
-      "@edufeed-org/oer-finder-plugin",
-      "@edufeed-org/oer-finder-api-client"
+      "esbuild"
     ],
     "overrides": {
       "nostr-tools": "~2.14.2",
       "@nostr-dev-kit/ndk": "^2.14.2",
-      "@edufeed-org/oer-finder-api-client": "github:edufeed-org/oer-finder-plugin#v0.1.1&path:packages/oer-finder-api-client"
+      "@edufeed-org/oer-finder-api-client": "github:edufeed-org/oer-finder-plugin#v0.1.3&path:packages/oer-finder-api-client"
     },
     "ignoredBuiltDependencies": [
       "svelte-preprocess"
     ]
   },
   "dependencies": {
-    "@edufeed-org/oer-finder-plugin": "github:edufeed-org/oer-finder-plugin#v0.1.1&path:packages/oer-finder-plugin",
+    "@edufeed-org/oer-finder-plugin": "github:edufeed-org/oer-finder-plugin#v0.1.3&path:packages/oer-finder-plugin",
     "@nostr-dev-kit/ndk": "2.14.2",
     "@nostr-dev-kit/svelte": "^2.0.8",
     "@tiptap/core": "^3.13.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,15 +7,15 @@ settings:
 overrides:
   nostr-tools: ~2.14.2
   '@nostr-dev-kit/ndk': ^2.14.2
-  '@edufeed-org/oer-finder-api-client': github:edufeed-org/oer-finder-plugin#v0.1.1&path:packages/oer-finder-api-client
+  '@edufeed-org/oer-finder-api-client': github:edufeed-org/oer-finder-plugin#v0.1.3&path:packages/oer-finder-api-client
 
 importers:
 
   .:
     dependencies:
       '@edufeed-org/oer-finder-plugin':
-        specifier: github:edufeed-org/oer-finder-plugin#v0.1.1&path:packages/oer-finder-plugin
-        version: https://codeload.github.com/edufeed-org/oer-finder-plugin/tar.gz/bc91e343f70bf16a8f96ed78e98222623cd850e0#path:packages/oer-finder-plugin
+        specifier: github:edufeed-org/oer-finder-plugin#v0.1.3&path:packages/oer-finder-plugin
+        version: https://codeload.github.com/edufeed-org/oer-finder-plugin/tar.gz/9e4f710b580f4c5ece75e6211ff53cae840f6e8d#path:packages/oer-finder-plugin
       '@nostr-dev-kit/ndk':
         specifier: ^2.14.2
         version: 2.17.4(nostr-tools@2.14.3(typescript@5.9.3))
@@ -268,12 +268,12 @@ packages:
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
 
-  '@edufeed-org/oer-finder-api-client@https://codeload.github.com/edufeed-org/oer-finder-plugin/tar.gz/bc91e343f70bf16a8f96ed78e98222623cd850e0#path:packages/oer-finder-api-client':
-    resolution: {path: packages/oer-finder-api-client, tarball: https://codeload.github.com/edufeed-org/oer-finder-plugin/tar.gz/bc91e343f70bf16a8f96ed78e98222623cd850e0}
+  '@edufeed-org/oer-finder-api-client@https://codeload.github.com/edufeed-org/oer-finder-plugin/tar.gz/9e4f710b580f4c5ece75e6211ff53cae840f6e8d#path:packages/oer-finder-api-client':
+    resolution: {path: packages/oer-finder-api-client, tarball: https://codeload.github.com/edufeed-org/oer-finder-plugin/tar.gz/9e4f710b580f4c5ece75e6211ff53cae840f6e8d}
     version: 0.0.4
 
-  '@edufeed-org/oer-finder-plugin@https://codeload.github.com/edufeed-org/oer-finder-plugin/tar.gz/bc91e343f70bf16a8f96ed78e98222623cd850e0#path:packages/oer-finder-plugin':
-    resolution: {path: packages/oer-finder-plugin, tarball: https://codeload.github.com/edufeed-org/oer-finder-plugin/tar.gz/bc91e343f70bf16a8f96ed78e98222623cd850e0}
+  '@edufeed-org/oer-finder-plugin@https://codeload.github.com/edufeed-org/oer-finder-plugin/tar.gz/9e4f710b580f4c5ece75e6211ff53cae840f6e8d#path:packages/oer-finder-plugin':
+    resolution: {path: packages/oer-finder-plugin, tarball: https://codeload.github.com/edufeed-org/oer-finder-plugin/tar.gz/9e4f710b580f4c5ece75e6211ff53cae840f6e8d}
     version: 0.0.6
 
   '@esbuild/aix-ppc64@0.25.10':
@@ -3314,13 +3314,13 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
-  '@edufeed-org/oer-finder-api-client@https://codeload.github.com/edufeed-org/oer-finder-plugin/tar.gz/bc91e343f70bf16a8f96ed78e98222623cd850e0#path:packages/oer-finder-api-client':
+  '@edufeed-org/oer-finder-api-client@https://codeload.github.com/edufeed-org/oer-finder-plugin/tar.gz/9e4f710b580f4c5ece75e6211ff53cae840f6e8d#path:packages/oer-finder-api-client':
     dependencies:
       openapi-fetch: 0.13.8
 
-  '@edufeed-org/oer-finder-plugin@https://codeload.github.com/edufeed-org/oer-finder-plugin/tar.gz/bc91e343f70bf16a8f96ed78e98222623cd850e0#path:packages/oer-finder-plugin':
+  '@edufeed-org/oer-finder-plugin@https://codeload.github.com/edufeed-org/oer-finder-plugin/tar.gz/9e4f710b580f4c5ece75e6211ff53cae840f6e8d#path:packages/oer-finder-plugin':
     dependencies:
-      '@edufeed-org/oer-finder-api-client': https://codeload.github.com/edufeed-org/oer-finder-plugin/tar.gz/bc91e343f70bf16a8f96ed78e98222623cd850e0#path:packages/oer-finder-api-client
+      '@edufeed-org/oer-finder-api-client': https://codeload.github.com/edufeed-org/oer-finder-plugin/tar.gz/9e4f710b580f4c5ece75e6211ff53cae840f6e8d#path:packages/oer-finder-api-client
       lit: 3.3.1
 
   '@esbuild/aix-ppc64@0.25.10':

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,9 +9,6 @@ export default defineConfig({
 		sveltekit(),
 		devtoolsJson()
 	],
-	ssr: {
-		noExternal: ['@edufeed-org/oer-finder-plugin']
-	},
 	test: {
 		expect: { requireAssertions: true },
 		projects: [


### PR DESCRIPTION
Now uses the dist folder that is provided instead of building it again which lead to potential problems with different build settings