### PR TITLE
Fix card view and add column

### DIFF
--- a/src/routes/cardsboard/Board.svelte
+++ b/src/routes/cardsboard/Board.svelte
@@ -21,35 +21,30 @@
 	// Direkt auf settingsStore.settings zugreifen (Svelte 5 Runes)
 	let settings = $derived(settingsStore.settings);
 
-	// Intelligenter Modus-Wechsel für Add Column Button
-	let isAddColumnFixed = $state(false);
+	// Sticky button - nur zeigen wenn scrollable button nicht sichtbar ist
+	let showStickyButton = $state(false);
+	let scrollableButtonElement: HTMLElement | undefined;
 
-	// Prüfe ob Board horizontal scrollt (zu viele Spalten)
+	// Intersection Observer für scrollable button
 	$effect(() => {
-		if (!boardElement) return;
+		if (!scrollableButtonElement) return;
 
-		const checkScroll = () => {
-			if (boardElement) {
-				// Wenn scrollWidth > clientWidth, dann scrollt das Board horizontal
-				const hasScroll = boardElement.scrollWidth > boardElement.clientWidth;
-				isAddColumnFixed = hasScroll;
+		const observer = new IntersectionObserver(
+			(entries) => {
+				const entry = entries[0];
+				// Sticky button nur zeigen wenn scrollable button NICHT sichtbar ist
+				showStickyButton = !entry.isIntersecting;
+			},
+			{
+				root: boardElement,
+				threshold: 0.1
 			}
-		};
+		);
 
-		// Initial check
-		checkScroll();
+		observer.observe(scrollableButtonElement);
 
-		// Observer für Größenänderungen
-		const resizeObserver = new ResizeObserver(checkScroll);
-		resizeObserver.observe(boardElement);
-
-		// Auch bei Spalten-Änderungen prüfen (mit kleinem Delay für Rendering)
-		const columnsLength = columns.length; // ← Dependency tracking
-		setTimeout(checkScroll, 100);
-
-		// Cleanup
 		return () => {
-			resizeObserver.disconnect();
+			observer.disconnect();
 		};
 	});
 	
@@ -313,7 +308,7 @@
 	}
 
 	.add-column-button {
-		flex: 0 0 80px;
+		flex: 0 0 280px;
 		height: 100%;
 		display: flex;
 		align-items: flex-start;
@@ -344,34 +339,35 @@
 		box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
 	}
 
-	/* Fixed mode - wenn zu viele Spalten (relativ zum Board-Container) */
-	.add-column-button-fixed {
-		position: absolute;
-		right: 0.5rem;
+	/* Sticky button - appears when scrollable button is not visible */
+	.sticky-add-column {
+		position: fixed;
+		right: 1rem;
 		top: 50%;
 		transform: translateY(-50%);
-		z-index: 50;
+		z-index: 100;
+		transition: opacity 0.2s ease, transform 0.2s ease;
 	}
 
-	.add-column-button-fixed button {
-		width: 48px;
-		height: 48px;
+	.sticky-add-column button {
+		width: 56px;
+		height: 56px;
 		border-radius: var(--radius-md);
-		border: 1px solid var(--accent);
+		border: 2px solid var(--accent);
 		background: var(--background);
 		color: var(--primary-foreground);
 		cursor: pointer;
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+		box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
 		transition: all 0.2s ease;
 	}
 
-	.add-column-button-fixed button:hover {
+	.sticky-add-column button:hover {
 		background: var(--accent);
-		transform: scale(1.05);
-		box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+		transform: scale(1.1);
+		box-shadow: 0 6px 20px rgba(0, 0, 0, 0.3);
 	}
 	
 </style>
@@ -404,9 +400,9 @@
  					/>
  			</div>
      {/each}
-	<!-- Add Column Button - intelligenter Modus-Wechsel -->
+	<!-- Add Column Button - scrolls with board content -->
 	{#if !readOnly}
-	<div class={isAddColumnFixed ? 'add-column-button-fixed' : 'add-column-button'}>
+	<div class="add-column-button" bind:this={scrollableButtonElement}>
 		<button
 			title="Neue Spalte hinzufügen"
 			aria-label="Neue Spalte hinzufügen"
@@ -422,12 +418,37 @@
 				}
 			}}
 		>
-			{#if !isAddColumnFixed}
-				<SquarePlusIcon class="h-4.5 w-4.5" /> <span class="ml-2">Spalte hinzufügen</span>
-			{:else}
-				<SquarePlusIcon class="h-6 w-6" />
-			{/if}
+			<SquarePlusIcon class="h-4.5 w-4.5" /> <span class="ml-2">Spalte hinzufügen</span>
 		</button>
 	</div>
 	{/if}
 </section>
+
+<!-- Sticky Add Column Button - only visible when scrollable button is out of view -->
+{#if !readOnly && showStickyButton}
+	<div class="sticky-add-column">
+		<button
+			title="Neue Spalte hinzufügen"
+			aria-label="Neue Spalte hinzufügen"
+			onclick={() => {
+				console.log('➕ Adding new column (sticky)...');
+				try {
+					boardStore.createColumn('Neue Spalte');
+					// Scroll to the end to show the new column
+					if (boardElement) {
+						setTimeout(() => {
+							boardElement.scrollLeft = boardElement.scrollWidth;
+						}, 100);
+					}
+				} catch (error) {
+					console.error('❌ Fehler beim Erstellen der Spalte:', error);
+					toast.error('Keine Berechtigung', {
+						description: 'Du musst angemeldet sein und Maintainer dieses Boards sein, um Spalten zu erstellen.'
+					});
+				}
+			}}
+		>
+			<SquarePlusIcon class="h-6 w-6" />
+		</button>
+	</div>
+{/if}

--- a/src/routes/cardsboard/Card.svelte
+++ b/src/routes/cardsboard/Card.svelte
@@ -1,28 +1,14 @@
 <script lang="ts">
 	import { boardStore, type CardItem } from "$lib/stores/kanbanStore.svelte.js";
 	import * as Card from "../../lib/components/ui/card/index.js";
-	import * as Popover from "$lib/components/ui/popover/index.js";
 	import { Button } from "$lib/components/ui/button/index.js";
-	import { Input } from "$lib/components/ui/input/index.js";
-	import { Separator } from "$lib/components/ui/separator/index.js";
 	import { Badge } from "$lib/components/ui/badge/index.js";
 	import CardDialog from "./CardDialog.svelte";
 	import CardViewDialog from "./CardViewDialog.svelte";
 	import CardSidebar from "./CardSidebar.svelte";
-	import AvatarStack from "./AvatarStack.svelte";
-	import ColorSelector from "./ColorSelector.svelte";
 	import MarkdownRenderer from '$lib/components/ui/markdown-renderer/MarkdownRenderer.svelte';
-	import EditIcon from '@lucide/svelte/icons/edit';
-	import FullscreenIcon from "@lucide/svelte/icons/fullscreen";
 	import MessageSquareIcon from "@lucide/svelte/icons/message-square";
-	import UserIcon from "@lucide/svelte/icons/user";
 	import LinkIcon from "@lucide/svelte/icons/link";
-	import EllipsisVerticalIcon from "@lucide/svelte/icons/ellipsis-vertical";
-	import { authStore } from "$lib/index.js";
-    import TrashIcon from "@lucide/svelte/icons/trash";
-	import PlusIcon from "@lucide/svelte/icons/plus";
-	import XIcon from "@lucide/svelte/icons/x";
-	import BrainIcon from "@lucide/svelte/icons/brain";
 
 	let {
 		card,

--- a/src/routes/cardsboard/CardDialog.svelte
+++ b/src/routes/cardsboard/CardDialog.svelte
@@ -1,13 +1,10 @@
 <script lang="ts">
 	import { z } from 'zod';
 	import * as Dialog from '$lib/components/ui/dialog/index.js';
-	import * as Tabs from '$lib/components/ui/tabs/index.js';
 	import { Field, FieldLabel, FieldContent, FieldError } from '$lib/components/ui/field/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
-	import { Textarea } from '$lib/components/ui/textarea/index.js';
 	import { Badge } from '$lib/components/ui/badge/index.js';
-	import { Separator } from '$lib/components/ui/separator/index.js';
 	import { boardStore } from '$lib/stores/kanbanStore.svelte.js';
 	import type { CardProps, PublishState } from '../../lib/classes/BoardModel.js';
   	import OerImagePicker from '$lib/components/OerImagePicker.svelte';

--- a/src/routes/cardsboard/CardViewDialog.svelte
+++ b/src/routes/cardsboard/CardViewDialog.svelte
@@ -5,19 +5,15 @@
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import { Textarea } from '$lib/components/ui/textarea/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
-	import * as Separator from '$lib/components/ui/separator/index.js';
 	import { boardStore } from '$lib/stores/kanbanStore.svelte.js';
 	import { authStore } from '$lib/stores/authStore.svelte.js';
 	import ColorSelector from './ColorSelector.svelte';
 	import * as Avatar from '$lib/components/ui/avatar/index.js';
 	import MarkdownRenderer from '$lib/components/ui/markdown-renderer/MarkdownRenderer.svelte';
-	import MarkdownEditor from '$lib/components/ui/markdown-editor/MarkdownEditor.svelte';
 	import SendIcon from '@lucide/svelte/icons/send';
 	import LoaderIcon from '@lucide/svelte/icons/loader';
 	import TrashIcon from '@lucide/svelte/icons/trash';
-	import EditIcon from '@lucide/svelte/icons/edit';
 	import PencilIcon from '@lucide/svelte/icons/pencil';
-	import EllipsisVerticalIcon from '@lucide/svelte/icons/ellipsis-vertical';
 	import CheckIcon from '@lucide/svelte/icons/check';
 	import CircleAlertIcon from '@lucide/svelte/icons/circle-alert';
 	import WifiOffIcon from '@lucide/svelte/icons/wifi-off';
@@ -35,25 +31,17 @@
 		onEditMode?: () => void;
 		readOnly?: boolean;
 	}
-	let showModal = $state(false);
 	let { cardId, open = $bindable(), onEditMode, readOnly = false }: Props = $props();
 
 	let commentText = $state('');
 	let isSubmitting = $state(false);
-	let isLoadingComments = $state(false);
-	let isCommentFieldFocused = $state(false);
 	let editName = $state('');
 	let selectedColor = $state('slate');
-	
-	// 🆕 INLINE-EDITING STATE
-	let isEditingDescription = $state(false);
 	let editDescription = $state('');
 	let newLabelInput = $state('');
 	let editLabels = $state<string[]>([]);
 	let newLinkUrl = $state('');
 	let newLinkTitle = $state('');
-	
-	// 🆕 IMAGE-EDITING STATE
 	let isEditingImage = $state(false);
 	let editImageUrl = $state('');
 	let imageMode = $state<'url' | 'oer'>('url');
@@ -145,16 +133,6 @@
 		editLabels = [...(card.labels || [])];
 	});
 
-	// Auto-Focus: Bei leerer Karte direkt Beschreibungs-Editor öffnen
-	$effect(() => {
-		if (open && !card.description && !card.image) {
-			// Kurzer Timeout damit Dialog vollständig gerendert ist
-			setTimeout(() => {
-				isEditingDescription = true;
-			}, 100);
-		}
-	});
-
 	const attendees = $derived(
 		card.attendees && card.attendees.length > 0
 			? card.attendees
@@ -162,6 +140,20 @@
 				? [card.authorName]
 				: []
 	);
+
+	// Auto-adjust textarea height when description changes
+	$effect(() => {
+		if (!readOnly && editDescription !== undefined) {
+			// Small delay to ensure DOM is updated
+			setTimeout(() => {
+				const textarea = document.querySelector('textarea[placeholder="Beschreibung eingeben..."]') as HTMLTextAreaElement;
+				if (textarea) {
+					textarea.style.height = 'auto';
+					textarea.style.height = textarea.scrollHeight + 'px';
+				}
+			}, 0);
+		}
+	});
 
 	/**
 	 * Handles comment submission
@@ -188,21 +180,6 @@
 			console.error('❌ Fehler beim Hinzufügen des Kommentars:', error);
 		} finally {
 			isSubmitting = false;
-		}
-	}
-
-	/**
-	 * 🔥 Load remote comments from Nostr relays
-	 */
-	async function handleLoadComments() {
-		try {
-			isLoadingComments = true;
-			await boardStore.loadComments(String(cardId));
-			console.log('✅ Comments loaded from Nostr');
-		} catch (error) {
-			console.error('❌ Failed to load comments:', error);
-		} finally {
-			isLoadingComments = false;
 		}
 	}
 
@@ -321,19 +298,12 @@
 	// ============================================================================
 	
 	/**
-	 * Beschreibung speichern und Editor schließen
+	 * Beschreibung speichern
 	 */
 	function handleSaveDescription() {
-		boardStore.updateCard(card.id as string, { content: editDescription });
-		isEditingDescription = false;
-	}
-	
-	/**
-	 * Beschreibung bearbeiten abbrechen
-	 */
-	function handleCancelDescription() {
-		editDescription = card.description || '';
-		isEditingDescription = false;
+		if (editDescription !== card.description) {
+			boardStore.updateCard(card.id as string, { content: editDescription });
+		}
 	}
 	
 	/**
@@ -398,21 +368,8 @@
 		boardStore.updateCard(card.id as string, { links: updatedLinks });
 	}
 
-	function handleEditClick() {
-		showModal = true;
-	}
-
 	function getCardColor(colorName: string | undefined): string {
 		return colorName ? `var(--color-${colorName})` : 'var(--muted)';
-	}
-
-	/**
-	 * Switch to edit mode - closes view dialog and triggers edit dialog
-	 * Now allows both authenticated and anonymous users to edit
-	 */
-	function switchToEditMode() {
-		open = false;
-		onEditMode?.();
 	}
 </script>
 
@@ -423,17 +380,7 @@
 		style="border-bottom: 5px solid {getCardColor(selectedColor)};"
 	>
 		<!-- Header: 2 Zeilen Layout -->
-		<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-		<div 
-			role="presentation"
-			class="px-6 py-4 border-b bg-background space-y-3"
-			onclick={() => {
-				// Schließe Editor wenn auf Header geklickt wird
-				if (isEditingDescription) {
-					handleSaveDescription();
-				}
-			}}
-		>
+		<div class="px-6 py-4 border-b bg-background space-y-3">
 			<!-- Zeile 1: Heading (links) | Delete + Close Button (rechts) -->
 			<div class="flex items-center justify-between gap-4">
 					<!-- Author Avatar  {@const} müssen innerhalb von {#if} stehen -->
@@ -540,32 +487,15 @@
 						}} 
 						compact={true}
 					/>
-					
-				
 				</div>
 				{/if}
 			</div>
 		</div>
 
-		<!-- Main Content: Scrollable (Scroll-Lock wenn Editor aktiv) -->
-		<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-		<div 
-			role="presentation"
-			class="flex-1 px-6 py-4 space-y-4 {isEditingDescription ? 'overflow-hidden flex flex-col' : 'overflow-y-auto'}"
-			onclick={(e) => {
-				// Schließe Editor wenn außerhalb des Description-Bereichs geklickt wird
-				if (isEditingDescription) {
-					const target = e.target as HTMLElement;
-					const descriptionSection = document.querySelector('[data-description-section]');
-					if (descriptionSection && !descriptionSection.contains(target)) {
-						handleSaveDescription();
-					}
-				}
-			}}
-		>
-			<!-- Image Section (ausgeblendet während Description-Editor aktiv) -->
-			{#if !isEditingDescription}
-				<div class="space-y-2">
+		<!-- Main Content: Scrollable -->
+		<div class="flex-1 px-6 py-4 space-y-4 overflow-y-auto">
+			<!-- Image Section -->
+			<div class="space-y-2">
 					{#if !isEditingImage && !card.image}
 						<!-- Kein Bild: Button zum Hinzufügen (hidden in readOnly mode) -->
 						{#if !readOnly}
@@ -726,81 +656,35 @@
 						</div>
 					{/if}
 				</div>
-			{/if}
 
-			<!-- 🆕 Description mit TipTap-Editor (automatisch bei Focus/Blur) -->
-			<div 
-				class="{isEditingDescription ? 'flex-1 flex flex-col min-h-0' : ''}"
-				data-description-section
-			>
-				
-				{#if isEditingDescription}
-					<!-- TipTap Markdown Editor - wird bei Blur automatisch gespeichert -->
-					<div 
-						class="flex-1 flex flex-col min-h-0"
-						onfocusout={(e) => {
-							// Nur schließen wenn der Focus wirklich den Editor verlässt
-							const relatedTarget = e.relatedTarget as HTMLElement | null;
-							const container = e.currentTarget as HTMLElement;
-							
-							// Wenn relatedTarget null ist oder außerhalb des Containers liegt → schließen
-							if (!relatedTarget || !container.contains(relatedTarget)) {
-								// Kleiner Timeout um sicherzustellen, dass der Focus wirklich weg ist
-								// (TipTap hat manchmal interne Focus-Wechsel)
-								setTimeout(() => {
-									// Prüfe nochmal ob der Focus wirklich außerhalb ist
-									if (!container.contains(document.activeElement)) {
-										handleSaveDescription();
-									}
-								}, 50);
-							}
-						}}
-					>
-						<MarkdownEditor 
-							value={editDescription}
-							placeholder="Beschreibung eingeben..."
-							fullHeight={true}
-							onchange={(content) => editDescription = content}
-						/>
-					</div>
-				{:else if card.description}
-					<!-- Markdown-Anzeige - bei Klick wird Editor aktiviert (nur wenn nicht readOnly) -->
-					{#if readOnly}
-						<div class="min-h-[7.5rem] p-3 bg-muted/50 rounded-md text-sm border border-[var(--ring)] transition-colors">
+			<!-- Description Field - Inline Editing -->
+			<div class="space-y-2">
+				<h3 class="text-sm font-semibold text-muted-foreground">Beschreibung</h3>
+				{#if readOnly}
+					{#if card.description}
+						<div class="min-h-[4rem] p-3 bg-muted/50 rounded-md text-sm border">
 							<MarkdownRenderer content={card.description} />
 						</div>
 					{:else}
-						<button 
-							type="button"
-							class="w-full text-left min-h-[7.5rem] p-3 bg-muted/50 rounded-md text-sm border border-[var(--ring)] cursor-text hover:bg-muted/70 transition-colors"
-							onclick={() => isEditingDescription = true}
-							aria-label="Beschreibung bearbeiten"
-						>
-							<MarkdownRenderer content={card.description} />
-						</button>
+						<p class="text-sm text-muted-foreground italic p-3">Keine Beschreibung vorhanden</p>
 					{/if}
 				{:else}
-					<!-- Platzhalter - bei Klick wird Editor aktiviert (nur wenn nicht readOnly) -->
-					{#if !readOnly}
-					<div 
-						class="p-3 bg-muted/30 rounded-md text-sm border border-dashed cursor-text hover:bg-muted/50 transition-colors text-muted-foreground"
-						onclick={() => isEditingDescription = true}
-						onfocusin={() => isEditingDescription = true}
-						onkeydown={(e) => e.key === 'Enter' && (isEditingDescription = true)}
-						role="textbox"
-						tabindex="0"
-						aria-label="Beschreibung hinzufügen"
-					>
-						Inhalt hinzufügen...
-					</div>
-					{:else}
-					<p class="text-sm text-muted-foreground italic">Keine Beschreibung vorhanden</p>
-					{/if}
+					<Textarea
+						bind:value={editDescription}
+						onblur={handleSaveDescription}
+						oninput={(e) => {
+							const target = e.target as HTMLTextAreaElement;
+							target.style.height = 'auto';
+							target.style.height = target.scrollHeight + 'px';
+						}}
+						placeholder="Beschreibung eingeben..."
+						class="min-h-[4rem] resize-none text-sm hover:bg-muted/50 transition-colors overflow-hidden"
+						style="height: auto;"
+					/>
 				{/if}
 			</div>
 
-			<!-- 🆕 Links Section mit Inline-Add (ausgeblendet während Editor aktiv) -->
-			{#if !isEditingDescription}
+			<!-- 🆕 Links Section mit Inline-Add -->
 			<div class="space-y-2">
 				<div class="flex items-center justify-between">
 					<h3 class="text-sm font-semibold text-muted-foreground">Links</h3>
@@ -887,13 +771,11 @@
 					Keine Links vorhanden
 				</div>
 				{/if}
-				{/if}
-			</div>
 			{/if}
-			<!-- Ende der ausgeblendeten Sections während Editor aktiv -->
+			</div>
 
-			<!-- Attendees / AvatarStack - mit Popover auf Avatar Click (ausgeblendet während Editor aktiv) -->
-			{#if attendees.length > 0 && !isEditingDescription}
+			<!-- Attendees / AvatarStack - mit Popover auf Avatar Click -->
+			{#if attendees.length > 0}
 				<div class="space-y-2">
 					<h3 class="text-sm font-semibold text-muted-foreground">Teilnehmer</h3>
 					<div class="flex items-center gap-3">
@@ -930,7 +812,6 @@
 				</div>
 			{/if}
 
-			{#if !isEditingDescription}
 			<!-- Divider -->
 			<div class="my-2 border-t"></div>
 
@@ -1053,8 +934,6 @@
 					bind:value={commentText}
 					disabled={isSubmitting}
 					class="min-h-20 resize-none"
-					onfocus={() => (isCommentFieldFocused = true)}
-					onblur={() => (isCommentFieldFocused = false)}
 				/>
 				<div class="flex justify-end gap-2">
 					<Button
@@ -1062,7 +941,7 @@
 						size="sm"
 						class="gap-2 bg-secondary"
 						onclick={() => (commentText = '')}
-						disabled={isSubmitting || (!isCommentFieldFocused && !commentText.trim())}
+						disabled={isSubmitting || !commentText.trim()}
 					>
 						Abbrechen
 					</Button>
@@ -1083,20 +962,6 @@
 				</div>
 			</div>
 			{/if}
-			{/if}
 		</div>
-
-		<!-- Footer: Edit Button (statt Schließen, da Dialog selbst Close hat) -->
-		<!-- <div class="px-6 py-4 border-t bg-muted/20 flex gap-2">
-			<Button 
-				variant="outline" 
-				size="sm"
-				class="gap-2 bg-primary"
-				onclick={switchToEditMode}
-			>
-				<EditIcon class="h-4 w-4" />
-				<span>Bearbeiten</span>
-			</Button>
-		</div> -->
 	</Dialog.Content>
 </Dialog.Root>


### PR DESCRIPTION
The PR #83 added better UX regarding card view and adding column. But they could be improved in two ways:

1. If the card had no description, the UI behaved switching between view and edit mode. In this PR we made it to edit inline.
2. The add column button was sticky, but with a fixed position. This PR fixed making it always sticky to the right-hand side.
