### PR TITLE
feat: fix Reaktive Loop

### DIFF
--- a/src/lib/components/ui/markdown-editor/MarkdownEditor.svelte
+++ b/src/lib/components/ui/markdown-editor/MarkdownEditor.svelte
@@ -40,6 +40,10 @@
 	let editor = $state<Editor | null>(null);
 	let isEditorReady = $state(false);
 	
+	// Track last value to prevent unnecessary updates
+	let lastExternalValue = $state(value);
+	let isInternalUpdate = false;
+	
 	// Markdown-it Instanz für die Konvertierung von Markdown zu HTML (beim Laden)
 	const md = new MarkdownIt({
 		html: true,
@@ -123,7 +127,9 @@
 				StarterKit.configure({
 					heading: {
 						levels: [1, 2, 3]
-					}
+					},
+					// Deaktiviere Link in StarterKit falls vorhanden (verwenden eigene Link-Extension)
+					link: false
 				}),
 				Link.configure({
 					openOnClick: false,
@@ -142,17 +148,25 @@
 			],
 			content: initialContent,
 			editable: !disabled,
-			onTransaction: () => {
-				// Force re-render für reactive updates
-				editor = editor;
-			},
-			onUpdate: ({ editor }) => {
+			// Removed onTransaction - was causing unnecessary re-renders
+			// The toolbar buttons use editor?.isActive() which works without it
+			onUpdate: ({ editor: ed }) => {
+				// Mark as internal update to prevent $effect loop
+				isInternalUpdate = true;
+				
 				// Konvertiere HTML zu Markdown beim Speichern!
-				const html = editor.getHTML();
+				const html = ed.getHTML();
 				const markdown = htmlToMarkdown(html);
+				lastExternalValue = markdown;
+				
 				if (onchange) {
 					onchange(markdown);
 				}
+				
+				// Reset flag after microtask
+				queueMicrotask(() => {
+					isInternalUpdate = false;
+				});
 			},
 			editorProps: {
 				handlePaste: (view, event) => {
@@ -187,14 +201,23 @@
 		}
 	});
 	
-	// Update content wenn value von außen ändert
+	// Update content wenn value von außen ändert (nicht von internen Updates)
 	$effect(() => {
-		if (editor && !editor.isFocused) {
-			const htmlContent = markdownToHtml(value);
-			if (htmlContent !== editor.getHTML()) {
-				editor.commands.setContent(htmlContent);
-			}
-		}
+		// Skip if this is our own update or editor isn't ready
+		if (!editor || isInternalUpdate) return;
+		
+		// Skip if value hasn't actually changed from external source
+		if (value === lastExternalValue) return;
+		
+		// Only update if editor is not focused (user not typing)
+		if (editor.isFocused) return;
+		
+		// Update tracking
+		lastExternalValue = value;
+		
+		// Convert and set content
+		const htmlContent = markdownToHtml(value);
+		editor.commands.setContent(htmlContent, { emitUpdate: false });
 	});
 	
 	// Update editable state wenn disabled ändert


### PR DESCRIPTION
## Problembeschreibung

Die App hing bei manchen Karten, sobald der TipTap-Editor aktiviert wurde - besonders bei großen Boards mit vielen Karten. Zusätzlich gab es eine Warnung wegen doppelter Link-Extension.

## Ursachen

1. **Duplicate Extension Warning**: Link-Extension war sowohl im StarterKit als auch separat konfiguriert
2. **Reaktive Loop**: Der `$effect` für externe Updates triggerte bei jedem internen Update erneut
3. **Unnötige Re-Renders**: `onTransaction` Handler triggerte bei jeder Cursor-Bewegung

## Lösung

### 1. Duplicate Extension Fix
- `link: false` zu `StarterKit.configure()` hinzugefügt

### 2. Performance-Optimierungen
- `isInternalUpdate` Flag verhindert, dass der `$effect` bei internen Updates triggert
- `lastExternalValue` Tracking verhindert unnötige Updates bei gleichem Wert
- `onTransaction` Handler entfernt (unnötig für Funktionalität)
- `{ emitUpdate: false }` bei `setContent()` verhindert Update-Events
- Schutz bei aktivem Fokus: `$effect` aktualisiert nicht während User tippt

## Geänderte Dateien

- `src/lib/components/ui/markdown-editor/MarkdownEditor.svelte`

## Testing

- [x] `pnpm check` - 0 Fehler, 0 Warnungen
- [x] Manuell: Große Boards mit vielen Karten öffnen
- [x] Manuell: Editor-Funktionalität (Bold, Italic, Links) testen