### PR TITLE
Inline editing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,8 @@ PR.md
 scripts/load-env.ps1
 scripts/run-with-env.ps1
 static/config.github.json
+
+# tailwind logs
+tailwind.config.js.timestamp-*
+tailwind.log
+tailwindcss-*.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog
 
+## Version 4.7.25 - Inline-Editing & Mobile UX 📝
+
+**Datum:** 31. Januar 2026  
+**Branch:** `inline-editing` → `cardsboard`  
+**Status:** ✅ Implementiert
+
+### ✨ Neue Features
+
+#### 1. Inline-Editing für Titel
+- **Board-Titel**: Klick in Topbar startet Inline-Editing (mit Stift-Icon bei Hover)
+- **Spaltentitel**: Klick auf Spaltenname startet Inline-Editing
+- Enter speichert, Escape bricht ab
+- Toast-Benachrichtigung bei Speicherung
+- Separater Drag-Handle verhindert Konflikte mit DnD
+
+#### 2. Globaler AI-Kontext-Store
+- **Neuer Store**: `aiContextStore.svelte.ts` für persistenten AI-Kontext
+- Kontext-Karten bleiben erhalten, auch wenn Sidebar geschlossen wird
+- Methoden: `addCard()`, `removeCard()`, `clear()`, `hasCard()`
+
+#### 3. Mobile UX Verbesserungen
+- **AI-Kontext-Button** (🧠) in CardDetailsDialog für Mobile
+- Alternative zu CTRL+Klick/Long-Press (Long-Press kollidiert mit Drag)
+- Globaler Event-Handler in +page.svelte für Sidebar-unabhängige Funktion
+
+#### 4. UI-Optimierungen
+- **Hamburger-Menü** in BoardsList für Board-Einstellungen
+- **Profilbearbeitung** in User-Dropdown (LeftSidebarFooter)
+- Konsistentes Menü-Styling mit `bg-muted/80`
+- Reduzierte Border-Dicke für dezenteres Design
+
+### 📁 Geänderte Dateien
+| Datei | Änderung |
+|-------|----------|
+| `Column.svelte` | +51 Zeilen - Inline-Editing |
+| `Topbar.svelte` | +85 Zeilen - Board-Titel Inline-Editing |
+| `+page.svelte` | +48/-91 Zeilen - Globaler AI-Handler |
+| `aiContextStore.svelte.ts` | +69 Zeilen - **Neu** |
+| `CardDetailsDialog.svelte` | +41 Zeilen - AI-Button |
+| `BoardsList.svelte` | +30 Zeilen - Hamburger-Menü |
+| `LeftSidebarFooter.svelte` | +9 Zeilen - Profilbearbeitung |
+
+### 📚 Dokumentation
+- Neuer Guide: `docs/GUIDES/INLINE-EDITING.md`
+
+---
+
 ## Version 4.7.24 - OER Search: Multi-Source + Bildungsstufe 🎯
 
 **Datum:** 30. Januar 2026  

--- a/docs/COLLABORATION/ROADMAP.md
+++ b/docs/COLLABORATION/ROADMAP.md
@@ -139,31 +139,34 @@
 - **Dokumentation:** `docs/FEATURE/DEMO-BOARD-SYSTEM.md` (vollständige Spezifikation)
 - **Tests:** TypeScript 0 errors, Development Server läuft erfolgreich
 
-### PHASE 2: UI COMPONENTS & UX (⚠️ 5% COMPLETE)
+### PHASE 2: UI COMPONENTS & UX (🔄 20% COMPLETE)
 
-#### Status: **UI Komponenten vorhanden, aber nicht vollständig integriert**
+#### Status: **UI Komponenten vorhanden, Inline-Editing implementiert!**
 
 **Was bereits implementiert ist:**
 - ✅ Card.svelte - Drag-and-Drop mit Icons
-- ✅ Column.svelte - mit $effect Auto-Sync
+- ✅ Column.svelte - mit $effect Auto-Sync + **Inline-Editing für Spaltentitel** 🆕
 - ✅ CardDialog.svelte - Edit Modal
-- ✅ CardDetailsDialog.svelte - View Modal mit Kommentaren
-- ✅ Topbar.svelte - mit Settings + Share-Link
-- ✅ BoardsList.svelte - Board-Auswahl
+- ✅ CardDetailsDialog.svelte - View Modal mit Kommentaren + **AI-Kontext-Button** 🆕
+- ✅ Topbar.svelte - mit Settings + Share-Link + **Inline-Editing für Board-Titel** 🆕
+- ✅ BoardsList.svelte - Board-Auswahl + **Hamburger-Menü** 🆕
 - ✅ SettingsPanel.svelte - neuer Settings-Component
 - ✅ UI Components: Progress, Slider, Switch, Spinner (neu!)
 - ✅ ActionConfirmationDialog.svelte (Bestätigung für Aktionen)
+- ✅ **aiContextStore.svelte.ts** - Globaler Store für AI-Kontext-Karten 🆕
+- ✅ **LeftSidebarFooter.svelte** - Profilbearbeitungsoption 🆕
 
 **Was noch fehlt:**
-- ❌ Vollständige Responsive Design (Mobile-First)
+- 🟡 Vollständige Responsive Design (Mobile-First) - **Mobile AI-Kontext verbessert** 🆕
 - 🟡 CSS Button Handling teilweise schlecht gelöst
 - ✅ **Dark Mode** - IMPLEMENTIERT! (settingsStore.theme, Topbar.svelte, 🟡 Settings wird aber nicht berücksichtigt beim reload)
 - ✅ **Settings Store** - KOMPLETT VORHANDEN! (971 Zeilen, alle Features)
+- ✅ **Inline-Editing** - Board-Titel + Spaltentitel (Klick zum Bearbeiten) 🆕
 - ❌ Accessibility (A11y) vollständig durchgetest
 - ❌ Performance Optimization (virtualization, lazy loading)
 - ❌ Error Boundaries implementieren
 - 🟡 **Paste System** - DUPLIKAT! (lib/paste/ UND boardstore/paste.ts)
-- ToDo: **8-12 Tage** (Mobile, A11y, Performance, Paste-Konsolidierung)
+- ToDo: **6-10 Tage** (Mobile, A11y, Performance, Paste-Konsolidierung)
 
 ### PHASE 3: KI-INTEGRATION (✅ 95% COMPLETE!)
 
@@ -1723,5 +1726,5 @@ FEBRUAR 2026:
 
 ---
 
-**Zuletzt aktualisiert:** 10. November 2025 (Nostr Sync Sprint Complete!)  
-**Nächste Überprüfung:** Nach Merge-LWW Integration (15.11.2025)
+**Zuletzt aktualisiert:** 31. Januar 2026
+

--- a/docs/GUIDES/INLINE-EDITING.md
+++ b/docs/GUIDES/INLINE-EDITING.md
@@ -1,0 +1,279 @@
+# Inline-Editing Guide
+
+**Version:** 1.0  
+**Datum:** 31. Januar 2026  
+**Status:** ✅ Implementiert (Branch: `inline-editing`)
+
+---
+
+## 🎯 Übersicht
+
+Das Kanban-Board unterstützt Inline-Editing für Board- und Spaltentitel. Anstatt einen Dialog zu öffnen, können Benutzer direkt auf den Titel klicken und ihn bearbeiten.
+
+## ✨ Features
+
+### 1. Board-Titel Inline-Editing (Topbar.svelte)
+
+**Verhalten:**
+- **Aktivierung**: Klick auf den Board-Titel
+- **Visueller Hinweis**: Stift-Icon erscheint bei Hover
+- **Speichern**: Enter-Taste
+- **Abbrechen**: Escape-Taste oder Klick außerhalb
+- **Feedback**: Toast-Benachrichtigung "Board-Titel gespeichert"
+
+**Technische Details:**
+```svelte
+<script lang="ts">
+  let isEditingBoardTitle = $state(false);
+  let editableBoardTitle = $state(boardStore.board?.name || '');
+  
+  function handleBoardTitleSave() {
+    if (editableBoardTitle.trim() && boardStore.board) {
+      boardStore.updateBoard({ name: editableBoardTitle.trim() });
+      toast.success('Board-Titel gespeichert');
+    }
+    isEditingBoardTitle = false;
+  }
+  
+  function handleBoardTitleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleBoardTitleSave();
+    } else if (e.key === 'Escape') {
+      isEditingBoardTitle = false;
+      editableBoardTitle = boardStore.board?.name || '';
+    }
+  }
+</script>
+
+{#if isEditingBoardTitle}
+  <input
+    type="text"
+    bind:value={editableBoardTitle}
+    onkeydown={handleBoardTitleKeydown}
+    onblur={handleBoardTitleSave}
+    class="bg-transparent border-b border-primary"
+  />
+{:else}
+  <button onclick={() => isEditingBoardTitle = true} class="group">
+    <span>{boardStore.board?.name}</span>
+    <PencilIcon class="opacity-0 group-hover:opacity-100" />
+  </button>
+{/if}
+```
+
+### 2. Spaltentitel Inline-Editing (Column.svelte)
+
+**Verhalten:**
+- **Aktivierung**: Klick auf den Spaltentitel
+- **Drag-Konflikt vermieden**: Separater Drag-Handle (`grip-vertical`)
+- **Speichern**: Enter-Taste
+- **Abbrechen**: Escape-Taste
+- **Read-Only-Modus**: Editing deaktiviert wenn `readOnly={true}`
+
+**Technische Details:**
+```svelte
+<script lang="ts">
+  let isEditingTitle = $state(false);
+  let editableTitle = $state(column.name);
+  
+  function handleTitleSave() {
+    if (editableTitle.trim() && editableTitle !== column.name) {
+      boardStore.updateColumn(column.id, { name: editableTitle.trim() });
+    }
+    isEditingTitle = false;
+  }
+  
+  function handleTitleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleTitleSave();
+    } else if (e.key === 'Escape') {
+      isEditingTitle = false;
+      editableTitle = column.name;
+    }
+  }
+</script>
+
+<div class="column-header">
+  <!-- Drag Handle - nur dieses Element ist draggable -->
+  <button class="drag-handle cursor-grab">
+    <GripVerticalIcon class="h-4 w-4" />
+  </button>
+  
+  {#if isEditingTitle}
+    <input
+      type="text"
+      bind:value={editableTitle}
+      onkeydown={handleTitleKeydown}
+      onblur={handleTitleSave}
+    />
+  {:else}
+    <button 
+      onclick={() => !readOnly && (isEditingTitle = true)}
+      disabled={readOnly}
+    >
+      {column.name}
+    </button>
+  {/if}
+</div>
+```
+
+---
+
+## 🎨 Styling-Empfehlungen
+
+### Input-Feld im Edit-Modus
+
+```css
+/* Transparent Background für nahtloses Erscheinungsbild */
+input[type="text"] {
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid hsl(var(--primary));
+  outline: none;
+  font-size: inherit;
+  font-weight: inherit;
+}
+
+/* Dynamische Breite basierend auf Textlänge */
+input {
+  width: calc(var(--char-count, 10) * 0.6em + 1em);
+  min-width: 100px;
+  max-width: 300px;
+}
+```
+
+### Hover-Indikator
+
+```css
+/* Zeige Bearbeitbarkeit durch Hover-Effekt */
+.editable-title {
+  cursor: pointer;
+}
+
+.editable-title:hover {
+  text-decoration: underline;
+  text-decoration-style: dotted;
+}
+
+/* Stift-Icon nur bei Hover */
+.edit-icon {
+  opacity: 0;
+  transition: opacity 150ms;
+}
+
+.editable-title:hover .edit-icon {
+  opacity: 1;
+}
+```
+
+---
+
+## 🔧 Integration mit BoardStore
+
+### Speichern der Änderungen
+
+```typescript
+// Board-Titel aktualisieren
+boardStore.updateBoard({ name: newTitle });
+
+// Spalten-Titel aktualisieren
+boardStore.updateColumn(columnId, { name: newTitle });
+```
+
+### Validierung
+
+```typescript
+function validateTitle(title: string): boolean {
+  // Mindestens 1 Zeichen nach trim()
+  if (!title.trim()) return false;
+  
+  // Maximale Länge (optional)
+  if (title.length > 100) return false;
+  
+  return true;
+}
+```
+
+---
+
+## 📱 Mobile-Verhalten
+
+### Touch-Events
+
+- **Tap**: Aktiviert Inline-Editing (wie Klick)
+- **Long-Press**: Wird für Drag-and-Drop verwendet, NICHT für Editing
+- **Keyboard**: Virtuelles Keyboard erscheint automatisch
+
+### Fokus-Management
+
+```typescript
+// Auto-Fokus und Text-Selektion beim Start des Editings
+function startEditing(inputRef: HTMLInputElement) {
+  inputRef.focus();
+  inputRef.select(); // Gesamten Text markieren
+}
+```
+
+---
+
+## ⚠️ Bekannte Einschränkungen
+
+1. **Kein Multi-Line**: Titel sind immer einzeilig (kein `<textarea>`)
+2. **Keine Undo-Funktion**: Änderungen werden sofort gespeichert
+3. **Gleichzeitiges Editing**: Wenn zwei Benutzer gleichzeitig bearbeiten, gilt Last-Write-Wins
+
+---
+
+## 🧪 Testen
+
+### Manuelle Tests
+
+1. **Board-Titel**:
+   - [ ] Klick auf Titel → Input erscheint
+   - [ ] Enter → Speichert und zeigt Toast
+   - [ ] Escape → Verwirft Änderung
+   - [ ] Leerer Titel → Wird nicht gespeichert
+
+2. **Spaltentitel**:
+   - [ ] Klick auf Titel → Input erscheint
+   - [ ] Drag-Handle → Startet Drag (nicht Editing)
+   - [ ] Read-Only-Modus → Editing deaktiviert
+
+### Automatisierte Tests (Playwright)
+
+```typescript
+test('inline editing board title', async ({ page }) => {
+  await page.goto('/cardsboard');
+  
+  // Klick auf Board-Titel
+  await page.click('[data-testid="board-title"]');
+  
+  // Input sollte erscheinen
+  await expect(page.locator('input[data-testid="board-title-input"]')).toBeVisible();
+  
+  // Neuen Titel eingeben
+  await page.fill('input[data-testid="board-title-input"]', 'Neuer Titel');
+  await page.press('input[data-testid="board-title-input"]', 'Enter');
+  
+  // Toast überprüfen
+  await expect(page.locator('.toast')).toContainText('gespeichert');
+});
+```
+
+---
+
+## 📚 Verwandte Dokumentation
+
+- [PROP-VS-STATE-CHEATSHEET.md](./PROP-VS-STATE-CHEATSHEET.md) - State-Management in Svelte 5
+- [STORE-PATTERNS.md](./STORE-PATTERNS.md) - BoardStore Patterns
+- [PR.md](../../PR.md) - Pull Request Details
+
+---
+
+## 📝 Versionshistorie
+
+| Version | Datum | Änderungen |
+|---------|-------|------------|
+| 1.0 | 31.01.2026 | Initial Release - Board + Column Inline-Editing |

--- a/e2e/board-sharing.spec.ts
+++ b/e2e/board-sharing.spec.ts
@@ -250,8 +250,8 @@ async function createSharedBoard(page: Page, boardName: string) {
     await newBoardButton.click();
 
     // Wait for menu button to become visible after board creation
-    await expect(page.getByTitle('Menü')).toBeVisible({ timeout: 5000 });
-    await page.getByTitle('Menü').click({timeout: 2000});
+    await expect(page.getByTitle('Board Einstellungen')).toBeVisible({ timeout: 5000 });
+    await page.getByTitle('Board Einstellungen').click({timeout: 2000});
     
     // Wait for properties option to become visible
     await expect(page.getByTitle('Eigenschaften')).toBeVisible({ timeout: 5000 });
@@ -269,8 +269,8 @@ async function createSharedBoard(page: Page, boardName: string) {
 
 async function shareBoard(page: Page, targetUserPubkey: string, role: 'editor' | 'viewer') {
     // Wait for menu button to be visible before clicking
-    await expect(page.getByTitle('Menü')).toBeVisible({ timeout: 5000 });
-    await page.getByTitle('Menü').click();
+    await expect(page.getByTitle('Board Einstellungen')).toBeVisible({ timeout: 5000 });
+    await page.getByTitle('Board Einstellungen').click();
     
     // Wait for share option to be visible
     await expect(page.getByText('Board teilen')).toBeVisible({ timeout: 5000 });

--- a/e2e/board-sharing.spec.ts
+++ b/e2e/board-sharing.spec.ts
@@ -249,10 +249,16 @@ async function createSharedBoard(page: Page, boardName: string) {
     const newBoardButton = page.getByTestId('create-board-button');
     await newBoardButton.click();
 
+    // Wait for menu button to become visible after board creation
+    await expect(page.getByTitle('Menü')).toBeVisible({ timeout: 5000 });
     await page.getByTitle('Menü').click({timeout: 2000});
+    
+    // Wait for properties option to become visible
+    await expect(page.getByTitle('Eigenschaften')).toBeVisible({ timeout: 5000 });
     await page.getByTitle('Eigenschaften').click({timeout: 2000});
 
     const titleInput = page.locator('#board-title');
+    await expect(titleInput).toBeVisible({ timeout: 5000 });
     
     await titleInput.fill(boardName);
     await page.getByText('Speichern').click({timeout: 2000});
@@ -262,7 +268,12 @@ async function createSharedBoard(page: Page, boardName: string) {
 }
 
 async function shareBoard(page: Page, targetUserPubkey: string, role: 'editor' | 'viewer') {
+    // Wait for menu button to be visible before clicking
+    await expect(page.getByTitle('Menü')).toBeVisible({ timeout: 5000 });
     await page.getByTitle('Menü').click();
+    
+    // Wait for share option to be visible
+    await expect(page.getByText('Board teilen')).toBeVisible({ timeout: 5000 });
     await page.getByText('Board teilen').click();
     
     await expect(page.getByTestId('share-dialog')).toBeVisible();

--- a/src/app.css
+++ b/src/app.css
@@ -179,10 +179,19 @@ button.btn, .menu-item{
   color: var(--destructive-foreground) !important;
   border-color: var(--destructive) !important;
 }
-
+.editor-menu button.menu-item{
+  background-color: transparent;
+}
+.editor-menu button.menu-item:hover{
+  border-radius: 0!important;
+}
 button.btn:hover{
   border: 2px solid var(--border);
   border-color: var(--accent);
+}
+.hamburger-menu-button:hover, .hamburger-menu-button:active{
+  background-color: var(--primary) !important;
+  color: var(--foreground) !important;
 }
 
 button.btn:focus-visible,

--- a/src/lib/components/settings/SettingsPanel.svelte
+++ b/src/lib/components/settings/SettingsPanel.svelte
@@ -189,7 +189,7 @@
           <Separator />
           
           <!-- Max Cards Before Scroll -->
-          <div class="space-y-2">
+          <!-- <div class="space-y-2">
             <Label for="maxCards">
               Maximale Karten pro Spalte (vor Scrolling)
               <span class="text-muted-foreground ml-2">{localMaxCards}</span>
@@ -206,10 +206,10 @@
             <p class="text-sm text-muted-foreground">
               Nach wie vielen Karten soll eine Spalte scrollbar werden?
             </p>
-          </div>
+          </div> -->
           
           <!-- Column Width -->
-          <div class="space-y-2">
+          <!-- <div class="space-y-2">
             <Label for="columnWidth">
               Spaltenbreite (Pixel)
               <span class="text-muted-foreground ml-2">{localColumnWidth}px</span>
@@ -224,10 +224,10 @@
               onchange={handleColumnWidthChange}
               class="w-32"
             />
-          </div>
+          </div> -->
           
           <!-- Align Columns -->
-          <div class="flex items-center justify-between">
+          <!-- <div class="flex items-center justify-between">
             <div class="space-y-0.5">
               <Label>Spalten an maximale Höhe ausrichten</Label>
               <p class="text-sm text-muted-foreground">
@@ -238,13 +238,13 @@
               checked={settings.alignColumnsToMaxHeight}
               onCheckedChange={(checked) => settingsStore.setAlignColumnsToMaxHeight(checked)}
             />
-          </div>
+          </div> -->
           
-          <Separator />
+          <!-- <Separator /> -->
           
           <!-- Sidebar Visibility -->
           <div class="space-y-4">
-            <Label>Sidebar Sichtbarkeit</Label>
+            <!-- <Label>Sidebar Sichtbarkeit</Label>
             
             <div class="flex items-center justify-between">
               <div class="space-y-0.5">
@@ -264,7 +264,7 @@
                 checked={settings.showRightSidebar}
                 onCheckedChange={() => settingsStore.toggleRightSidebar()}
               />
-            </div>
+            </div> -->
             
             <!-- Max Boards in Sidebar -->
             <div class="space-y-2">

--- a/src/lib/stores/aiContextStore.svelte.ts
+++ b/src/lib/stores/aiContextStore.svelte.ts
@@ -1,0 +1,69 @@
+/**
+ * 🎯 AI Context Store - Speichert ausgewählte Karten für den AI-Kontext
+ * 
+ * Problem: Wenn die rechte Sidebar geschlossen wird (besonders auf Mobile),
+ * geht der lokale contextCards State im AIPanel verloren.
+ * 
+ * Lösung: Globaler Store der unabhängig vom AIPanel-Mount-Status existiert.
+ */
+
+export interface ContextCard {
+	cardId: string;
+	cardName: string;
+	columnId: string;
+	columnName: string;
+}
+
+// Globaler reaktiver State
+let contextCards = $state<ContextCard[]>([]);
+
+/**
+ * AI Context Store - Verwaltet Karten-Kontext für AI-Anfragen
+ */
+export const aiContextStore = {
+	/**
+	 * Alle Kontext-Karten abrufen
+	 */
+	get cards(): ContextCard[] {
+		return contextCards;
+	},
+
+	/**
+	 * Anzahl der Kontext-Karten
+	 */
+	get count(): number {
+		return contextCards.length;
+	},
+
+	/**
+	 * Karte zum Kontext hinzufügen (verhindert Duplikate)
+	 */
+	addCard(card: ContextCard): boolean {
+		if (contextCards.some(c => c.cardId === card.cardId)) {
+			return false; // Bereits vorhanden
+		}
+		contextCards = [...contextCards, card];
+		return true;
+	},
+
+	/**
+	 * Karte aus dem Kontext entfernen
+	 */
+	removeCard(cardId: string): void {
+		contextCards = contextCards.filter(c => c.cardId !== cardId);
+	},
+
+	/**
+	 * Alle Karten aus dem Kontext entfernen
+	 */
+	clear(): void {
+		contextCards = [];
+	},
+
+	/**
+	 * Prüft ob eine Karte bereits im Kontext ist
+	 */
+	hasCard(cardId: string): boolean {
+		return contextCards.some(c => c.cardId === cardId);
+	}
+};

--- a/src/routes/cardsboard/+page.svelte
+++ b/src/routes/cardsboard/+page.svelte
@@ -57,7 +57,9 @@ import { authStore } from '$lib';
 	});
 	
 	onDestroy(() => {
-		window.removeEventListener('addCardToAIContext', handleGlobalAddCardToContext as EventListener);
+		if (typeof window !== 'undefined') {
+			window.removeEventListener('addCardToAIContext', handleGlobalAddCardToContext as EventListener);
+		}
 	});
 
 	// Hook 1: Suppress passive event listener warnings for dnd-action

--- a/src/routes/cardsboard/+page.svelte
+++ b/src/routes/cardsboard/+page.svelte
@@ -11,13 +11,18 @@ import AIPanel from "./AIPanel.svelte";
 import type { Column } from "./types.js";
 import * as Resizable from "$lib/components/ui/resizable/index.js";
 import * as Sheet from "$lib/components/ui/sheet/index.js";
+import { Button } from "$lib/components/ui/button/index.js";
 import { boardStore } from "$lib/stores/kanbanStore.svelte.js";
 import { toast } from "svelte-sonner";
 import SquareKanbanIcon from '@lucide/svelte/icons/square-kanban';
+import MenuIcon from '@lucide/svelte/icons/menu';
 import { authStore } from '$lib';
 
 	// Reference to ImportPopover component for share-link preview
 	let importPopoverComponent: any;
+	
+	// Hamburger Menu State für Board-Einstellungen
+	let hamburgerMenuOpen = $state(false);
 	
 	// Share-Link Dialog State
 	let showFollowDialog = $state(false);
@@ -265,10 +270,26 @@ import { authStore } from '$lib';
 		
 		<!-- Left Sidebar Sheet (Mobile) -->
 		<Sheet.Root bind:open={leftSidebarOpen}>
-			<Sheet.Content side="left" class="w-[280px] sm:w-[320px] p-0">
-				<div class="p-4 h-full flex flex-col overflow-hidden">
+			<Sheet.Content side="left" class="w-[280px] sm:w-[320px] p-0 [&>button]:hidden">
+				<!-- Header mit Titel und Menü-Button -->
+				<div class="px-4 py-3 border-b-4 flex items-center justify-between">
+					<div class="flex items-center gap-2">
+						<SquareKanbanIcon class="h-5 w-5" />
+						<h2 class="font-semibold">Kanban-Editor</h2>
+					</div>
+					<Button
+						variant="ghost"
+						size="icon"
+						class="h-9 w-9"
+						title="Board Einstellungen"
+						onclick={() => { hamburgerMenuOpen = !hamburgerMenuOpen; }}
+					>
+						<MenuIcon class="h-5 w-5" />
+					</Button>
+				</div>
+				<div class="p-4 h-[calc(100%-3.5rem)] flex flex-col overflow-hidden">
 					<div class="flex-1 overflow-y-auto min-h-0">
-						<BoardsList {currentBoardId} />
+						<BoardsList {currentBoardId} bind:hamburgerMenuOpen />
 					</div>
 					<LeftSidebarFooter />
 				</div>
@@ -299,14 +320,24 @@ import { authStore } from '$lib';
 					class="border-r bg-muted/10 overflow-y-auto"
 					onResize={(size: number) => { leftSidebarSize = size; }}
 				>
-					<div class="p-4 border-b-4 max-h-15 flex">
+					<!-- Header der linken Sidebar -->
+					<div class="p-4 border-b-4 max-h-15 flex items-center justify-between">
 						<div class="flex items-center gap-2">
 							<SquareKanbanIcon /><h2 class="text-lg font-semibold">Kanban-Editor</h2>
 						</div>
+						<Button
+							variant="ghost"
+							size="icon"
+							class="h-9 w-9"
+							title="Board Einstellungen"
+							onclick={() => { hamburgerMenuOpen = !hamburgerMenuOpen; }}
+						>
+							<MenuIcon class="h-5 w-5" />
+						</Button>
 					</div>
 					<div class="p-4 h-[calc(100%-3.75rem)] flex flex-col overflow-hidden">
 						<div class="flex-1 overflow-y-auto min-h-0">
-							<BoardsList {currentBoardId} />
+							<BoardsList {currentBoardId} bind:hamburgerMenuOpen />
 						</div>
 						<LeftSidebarFooter />
 					</div>

--- a/src/routes/cardsboard/+page.svelte
+++ b/src/routes/cardsboard/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { onMount } from 'svelte';
+import { onMount, onDestroy } from 'svelte';
 import { replaceState } from '$app/navigation';
 import Board from "./Board.svelte";
 import BoardsList from "./BoardsList.svelte";
@@ -13,6 +13,7 @@ import * as Resizable from "$lib/components/ui/resizable/index.js";
 import * as Sheet from "$lib/components/ui/sheet/index.js";
 import { Button } from "$lib/components/ui/button/index.js";
 import { boardStore } from "$lib/stores/kanbanStore.svelte.js";
+import { aiContextStore, type ContextCard } from '$lib/stores/aiContextStore.svelte.js';
 import { toast } from "svelte-sonner";
 import SquareKanbanIcon from '@lucide/svelte/icons/square-kanban';
 import MenuIcon from '@lucide/svelte/icons/menu';
@@ -32,9 +33,32 @@ import { authStore } from '$lib';
 	// Mobile detection (screens < 768px are considered mobile)
 	let isMobile = $state(false);
 
+	// ==========================================================================
+	// GLOBAL AI CONTEXT EVENT HANDLER
+	// Muss global sein, damit es auch funktioniert wenn AIPanel geschlossen ist
+	// ==========================================================================
+	function handleGlobalAddCardToContext(e: CustomEvent<ContextCard>) {
+		const newCard = e.detail;
+		const added = aiContextStore.addCard(newCard);
+		if (added) {
+			toast.success(`"${newCard.cardName}" zum KI-Kontext hinzugefügt`);
+		} else {
+			toast.info(`Karte ist bereits im KI-Kontext`);
+		}
+	}
+
 	// ============================================================================
 	// LIFECYCLE: ONMOUNT HOOKS (Browser API calls - only once per component mount)
 	// ============================================================================
+
+	// Hook 0: Globaler Event-Listener für AI-Kontext (funktioniert auch bei geschlossener Sidebar)
+	onMount(() => {
+		window.addEventListener('addCardToAIContext', handleGlobalAddCardToContext as EventListener);
+	});
+	
+	onDestroy(() => {
+		window.removeEventListener('addCardToAIContext', handleGlobalAddCardToContext as EventListener);
+	});
 
 	// Hook 1: Suppress passive event listener warnings for dnd-action
 	// ✅ CORRECT: onMount for one-time side effects

--- a/src/routes/cardsboard/+page.svelte
+++ b/src/routes/cardsboard/+page.svelte
@@ -207,35 +207,23 @@ import { authStore } from '$lib';
 		cardsCount: columns.reduce((sum, col) => sum + col.items.length, 0)
 	});
 
-	// Sidebar states - jetzt mit Größen
+	// Sidebar states
 	let leftSidebarOpen = $state(true);
 	let rightSidebarOpen = $state(false);
-	let leftSidebarSize = $state(20);
-	let rightSidebarSize = $state(15);
 	
-	// Auto-close sidebars on mobile
+	// Auto-close left sidebar on mobile
 	$effect(() => {
 		if (isMobile) {
 			leftSidebarOpen = false;
 		}
 	});
 	
-	// Funktionen zum Toggle mit Größenänderung
+	// Toggle-Funktionen
 	function toggleLeftSidebar() {
-		if (leftSidebarOpen) {
-			leftSidebarSize = 0;
-		} else {
-			leftSidebarSize = 20;
-		}
 		leftSidebarOpen = !leftSidebarOpen;
 	}
 	
 	function toggleRightSidebar() {
-		if (rightSidebarOpen) {
-			rightSidebarSize = 0;
-		} else {
-			rightSidebarSize = 15;
-		}
 		rightSidebarOpen = !rightSidebarOpen;
 	}
 
@@ -273,19 +261,20 @@ import { authStore } from '$lib';
 			<Sheet.Content side="left" class="w-[280px] sm:w-[320px] p-0 [&>button]:hidden flex flex-col">
 				<!-- Header mit Titel und Menü-Button -->
 				<div class="px-4 py-3 border-b-4 flex items-center justify-between shrink-0">
-					<div class="flex items-center gap-2">
-						<SquareKanbanIcon class="h-5 w-5" />
-						<h2 class="font-semibold">Kanban-Editor</h2>
-					</div>
 					<Button
 						variant="ghost"
 						size="icon"
-						class="h-8 w-8"
+						class="h-8 w-8 hamburger-menu-button"
 						title="Board Einstellungen"
 						onclick={() => { hamburgerMenuOpen = !hamburgerMenuOpen; }}
 					>
 						<MenuIcon class="h-4 w-4" />
 					</Button>
+					<div class="flex items-center gap-2">
+						<!-- <SquareKanbanIcon class="h-5 w-5" /> -->
+						<h2 class="font-semibold">Kanban-Editor</h2>
+					</div>
+					
 				</div>
 				<!-- Content Bereich - flex-1 für den restlichen Platz -->
 				<div class="flex-1 flex flex-col overflow-hidden">
@@ -308,81 +297,75 @@ import { authStore } from '$lib';
 		</Sheet.Root>
 		
 	{:else}
-		<!-- Desktop Layout: Resizable sidebars -->
-		<Resizable.PaneGroup direction="horizontal" class="flex-1 overflow-hidden">
-			<!-- Linke Sidebar - nur rendern wenn offen -->
+		<!-- Desktop Layout: Left sidebar fixed, Main+Right resizable -->
+		<div class="flex flex-1 overflow-hidden">
+			
+			<!-- Linke Sidebar (Board-Liste) - feste Breite, außerhalb der PaneGroup -->
 			{#if leftSidebarOpen}
-				
-    
-				<Resizable.Pane 
-					defaultSize={20} 
-					minSize={15} 
-					maxSize={40} 
-					class="border-r bg-muted/10 flex flex-col overflow-hidden"
-					onResize={(size: number) => { leftSidebarSize = size; }}
-				>
-					<!-- Header der linken Sidebar -->
-					<div class="p-4 border-b-4 max-h-15 flex items-center justify-between shrink-0">
-						<div class="flex items-center gap-2">
-							<SquareKanbanIcon /><h2 class="text-lg font-semibold">Kanban-Editor</h2>
-						</div>
+				<aside class="w-[320px] border-r bg-background flex flex-col shrink-0">
+					<!-- Header mit Titel und Menü-Button -->
+					<div class="px-4 py-3 border-b-4 flex items-center justify-between shrink-0">
 						<Button
 							variant="ghost"
 							size="icon"
-							class="h-8 w-8"
+							class="h-8 w-8 hamburger-menu-button"
 							title="Board Einstellungen"
 							onclick={() => { hamburgerMenuOpen = !hamburgerMenuOpen; }}
 						>
-							<MenuIcon class="h-5 w-5" />
+							<MenuIcon class="h-4 w-4" />
 						</Button>
+						<div class="flex items-center gap-2">
+							<!-- <SquareKanbanIcon class="h-5 w-5" /> -->
+							<h2 class="font-semibold">Kanban-Editor</h2>
+						</div>
+						
 					</div>
+					<!-- Content Bereich -->
 					<div class="flex-1 flex flex-col overflow-hidden">
 						<div class="flex-1 overflow-y-auto min-h-0 p-2">
 							<BoardsList {currentBoardId} bind:hamburgerMenuOpen />
 						</div>
 						<LeftSidebarFooter />
 					</div>
+				</aside>
+			{/if}
+			
+			<!-- Main + Rechte Sidebar als separate PaneGroup -->
+			<Resizable.PaneGroup direction="horizontal" class="flex-1 overflow-hidden">
+				<!-- Hauptbereich -->
+				<Resizable.Pane defaultSize={rightSidebarOpen ? 75 : 100} minSize={50} class="flex flex-col overflow-hidden">
+					<main class="flex flex-1 flex-col overflow-hidden min-w-0">
+						<Topbar
+							onToggleLeftSidebar={toggleLeftSidebar}
+							onToggleRightSidebar={toggleRightSidebar}
+							{isMobile}
+						/>
+						
+						<div class="flex-1 overflow-hidden p-0 min-h-0">
+							<Board 
+								columns={columns} 
+								onFinalUpdate={handleBoardUpdated}
+							/>
+						</div>
+					</main>
 				</Resizable.Pane>
 				
-				<Resizable.Handle withHandle />
-			{/if}
-			
-			<!-- Hauptbereich -->
-			<Resizable.Pane defaultSize={70} minSize={40} class="flex flex-col overflow-hidden">
-				<main class="flex flex-1 flex-col overflow-hidden min-w-0">
-					<Topbar
-						onToggleLeftSidebar={toggleLeftSidebar}
-						onToggleRightSidebar={toggleRightSidebar}
-						{isMobile}
-					/>
+				{#if rightSidebarOpen}
+					<!-- Handle zwischen Main und rechter Sidebar -->
+					<Resizable.Handle withHandle />
 					
-					<div class="flex-1 overflow-hidden p-0 min-h-0">
-						<Board 
-							columns={columns} 
-							onFinalUpdate={handleBoardUpdated}
-						/>
-					</div>
-				</main>
-			</Resizable.Pane>
-			
-			<!-- Handle zwischen Main und rechter Sidebar -->
-			{#if rightSidebarOpen}
-				<Resizable.Handle withHandle />
-			{/if}
-			
-			<!-- Rechte Sidebar (KI-Agent) - nur rendern wenn offen -->
-			{#if rightSidebarOpen}
-				<Resizable.Pane 
-					defaultSize={20} 
-					minSize={15} 
-					maxSize={50} 
-					class="border-l bg-background"
-					onResize={(size: number) => { rightSidebarSize = size; }}
-				>
-					<AIPanel boardId={currentBoardId} />
-				</Resizable.Pane>
-			{/if}
-		</Resizable.PaneGroup>
+					<!-- Rechte Sidebar (KI-Agent) - resizable -->
+					<Resizable.Pane 
+						defaultSize={25} 
+						minSize={15} 
+						maxSize={50}
+						class="border-l bg-background"
+					>
+						<AIPanel boardId={currentBoardId} />
+					</Resizable.Pane>
+				{/if}
+			</Resizable.PaneGroup>
+		</div>
 	{/if}
 </div>
 

--- a/src/routes/cardsboard/+page.svelte
+++ b/src/routes/cardsboard/+page.svelte
@@ -13,6 +13,7 @@ import * as Resizable from "$lib/components/ui/resizable/index.js";
 import * as Sheet from "$lib/components/ui/sheet/index.js";
 import { boardStore } from "$lib/stores/kanbanStore.svelte.js";
 import { toast } from "svelte-sonner";
+import SquareKanbanIcon from '@lucide/svelte/icons/square-kanban';
 import { authStore } from '$lib';
 
 	// Reference to ImportPopover component for share-link preview
@@ -289,6 +290,8 @@ import { authStore } from '$lib';
 		<Resizable.PaneGroup direction="horizontal" class="flex-1 overflow-hidden">
 			<!-- Linke Sidebar - nur rendern wenn offen -->
 			{#if leftSidebarOpen}
+				
+    
 				<Resizable.Pane 
 					defaultSize={20} 
 					minSize={15} 
@@ -296,7 +299,12 @@ import { authStore } from '$lib';
 					class="border-r bg-muted/10 overflow-y-auto"
 					onResize={(size: number) => { leftSidebarSize = size; }}
 				>
-					<div class="p-4 h-full flex flex-col overflow-hidden">
+					<div class="p-4 border-b-4 max-h-15 flex">
+						<div class="flex items-center gap-2">
+							<SquareKanbanIcon /><h2 class="text-lg font-semibold">Kanban-Editor</h2>
+						</div>
+					</div>
+					<div class="p-4 h-[calc(100%-3.75rem)] flex flex-col overflow-hidden">
 						<div class="flex-1 overflow-y-auto min-h-0">
 							<BoardsList {currentBoardId} />
 						</div>

--- a/src/routes/cardsboard/+page.svelte
+++ b/src/routes/cardsboard/+page.svelte
@@ -270,9 +270,9 @@ import { authStore } from '$lib';
 		
 		<!-- Left Sidebar Sheet (Mobile) -->
 		<Sheet.Root bind:open={leftSidebarOpen}>
-			<Sheet.Content side="left" class="w-[280px] sm:w-[320px] p-0 [&>button]:hidden">
+			<Sheet.Content side="left" class="w-[280px] sm:w-[320px] p-0 [&>button]:hidden flex flex-col">
 				<!-- Header mit Titel und Menü-Button -->
-				<div class="px-4 py-3 border-b-4 flex items-center justify-between">
+				<div class="px-4 py-3 border-b-4 flex items-center justify-between shrink-0">
 					<div class="flex items-center gap-2">
 						<SquareKanbanIcon class="h-5 w-5" />
 						<h2 class="font-semibold">Kanban-Editor</h2>
@@ -280,15 +280,16 @@ import { authStore } from '$lib';
 					<Button
 						variant="ghost"
 						size="icon"
-						class="h-9 w-9"
+						class="h-8 w-8"
 						title="Board Einstellungen"
 						onclick={() => { hamburgerMenuOpen = !hamburgerMenuOpen; }}
 					>
-						<MenuIcon class="h-5 w-5" />
+						<MenuIcon class="h-4 w-4" />
 					</Button>
 				</div>
-				<div class="p-4 h-[calc(100%-3.5rem)] flex flex-col overflow-hidden">
-					<div class="flex-1 overflow-y-auto min-h-0">
+				<!-- Content Bereich - flex-1 für den restlichen Platz -->
+				<div class="flex-1 flex flex-col overflow-hidden">
+					<div class="flex-1 overflow-y-auto min-h-0 p-2">
 						<BoardsList {currentBoardId} bind:hamburgerMenuOpen />
 					</div>
 					<LeftSidebarFooter />
@@ -317,26 +318,26 @@ import { authStore } from '$lib';
 					defaultSize={20} 
 					minSize={15} 
 					maxSize={40} 
-					class="border-r bg-muted/10 overflow-y-auto"
+					class="border-r bg-muted/10 flex flex-col overflow-hidden"
 					onResize={(size: number) => { leftSidebarSize = size; }}
 				>
 					<!-- Header der linken Sidebar -->
-					<div class="p-4 border-b-4 max-h-15 flex items-center justify-between">
+					<div class="p-4 border-b-4 max-h-15 flex items-center justify-between shrink-0">
 						<div class="flex items-center gap-2">
 							<SquareKanbanIcon /><h2 class="text-lg font-semibold">Kanban-Editor</h2>
 						</div>
 						<Button
 							variant="ghost"
 							size="icon"
-							class="h-9 w-9"
+							class="h-8 w-8"
 							title="Board Einstellungen"
 							onclick={() => { hamburgerMenuOpen = !hamburgerMenuOpen; }}
 						>
 							<MenuIcon class="h-5 w-5" />
 						</Button>
 					</div>
-					<div class="p-4 h-[calc(100%-3.75rem)] flex flex-col overflow-hidden">
-						<div class="flex-1 overflow-y-auto min-h-0">
+					<div class="flex-1 flex flex-col overflow-hidden">
+						<div class="flex-1 overflow-y-auto min-h-0 p-2">
 							<BoardsList {currentBoardId} bind:hamburgerMenuOpen />
 						</div>
 						<LeftSidebarFooter />

--- a/src/routes/cardsboard/+page.svelte
+++ b/src/routes/cardsboard/+page.svelte
@@ -302,9 +302,9 @@ import { authStore } from '$lib';
 			
 			<!-- Linke Sidebar (Board-Liste) - feste Breite, außerhalb der PaneGroup -->
 			{#if leftSidebarOpen}
-				<aside class="w-[320px] border-r bg-background flex flex-col shrink-0">
+				<aside class="w-[320px] border-r-2 bg-background flex flex-col shrink-0">
 					<!-- Header mit Titel und Menü-Button -->
-					<div class="px-4 py-3 border-b-4 flex items-center justify-between shrink-0">
+					<div class="px-4 py-3 border-b-2 flex items-center justify-between shrink-0">
 						<Button
 							variant="ghost"
 							size="icon"
@@ -359,7 +359,7 @@ import { authStore } from '$lib';
 						defaultSize={25} 
 						minSize={15} 
 						maxSize={50}
-						class="border-l bg-background"
+						class="bg-background border-l-2"
 					>
 						<AIPanel boardId={currentBoardId} />
 					</Resizable.Pane>

--- a/src/routes/cardsboard/AIPanel.svelte
+++ b/src/routes/cardsboard/AIPanel.svelte
@@ -464,7 +464,7 @@ Antworte NUR mit der Markdown-Zusammenfassung, ohne zusätzliche Erklärungen.`;
 <div class="flex h-full flex-col overflow-hidden">
   
   <!-- Header -->
-  <div class="p-4 border-b-4 max-h-15 overflow-hidden">
+  <div class="p-4 border-b-2 max-h-14.5 overflow-hidden">
     <div class="flex items-center justify-between">
       <div class="flex items-center gap-2">
         <BrainIcon class="h-5 w-5 text-primary" />
@@ -478,7 +478,7 @@ Antworte NUR mit der Markdown-Zusammenfassung, ohne zusätzliche Erklärungen.`;
         class="h-7 gap-2"
       >
         <SquareSigmaIcon class="h-3 w-3" />
-        <span class="text-xs hidden sm:inline">Zusammenfassung</span>
+        <span class="text-xs hidden sm:inline">Summary</span>
       </Button>
     </div>
   </div>

--- a/src/routes/cardsboard/AIPanel.svelte
+++ b/src/routes/cardsboard/AIPanel.svelte
@@ -15,6 +15,7 @@
   import { chatStore } from '$lib/stores/chatStore.svelte.js';
   import { settingsStore } from '$lib/stores/settingsStore.svelte.js';
   import { boardStore } from '$lib/stores/kanbanStore.svelte.js';
+  import { aiContextStore, type ContextCard } from '$lib/stores/aiContextStore.svelte.js';
   import BrainIcon from '@lucide/svelte/icons/brain';
   import SendIcon from '@lucide/svelte/icons/send';
   import SparklesIcon from '@lucide/svelte/icons/sparkles';
@@ -59,39 +60,18 @@
   let aiSummaryError = $state<string | null>(null);
   let showSummarySection = $state(false);
   
-  // 🎯 Kontext-Karten (per CTRL+Klick oder Long-Press hinzugefügt)
-  interface ContextCard {
-    cardId: string;
-    cardName: string;
-    columnId: string;
-    columnName: string;
-  }
-  let contextCards = $state<ContextCard[]>([]);
-  
-  function handleAddCardToContext(e: CustomEvent<ContextCard>) {
-    const newCard = e.detail;
-    // Verhindere Duplikate
-    if (!contextCards.some(c => c.cardId === newCard.cardId)) {
-      contextCards = [...contextCards, newCard];
-    }
-  }
+  // 🎯 Kontext-Karten (per CTRL+Klick, Long-Press oder Button hinzugefügt)
+  // Nutzt globalen Store damit Karten erhalten bleiben wenn Sidebar geschlossen wird
+  // Event-Listener ist GLOBAL in +page.svelte registriert (funktioniert auch bei geschlossener Sidebar)
+  let contextCards = $derived(aiContextStore.cards);
   
   function removeContextCard(cardId: string) {
-    contextCards = contextCards.filter(c => c.cardId !== cardId);
+    aiContextStore.removeCard(cardId);
   }
   
   function clearAllContextCards() {
-    contextCards = [];
+    aiContextStore.clear();
   }
-  
-  // Event-Listener für CTRL+Klick/Long-Press
-  onMount(() => {
-    window.addEventListener('addCardToAIContext', handleAddCardToContext as EventListener);
-  });
-  
-  onDestroy(() => {
-    window.removeEventListener('addCardToAIContext', handleAddCardToContext as EventListener);
-  });
   
   // Chat Messages (derived from chatStore)
   let messages = $derived(chatStore.messages);

--- a/src/routes/cardsboard/Board.svelte
+++ b/src/routes/cardsboard/Board.svelte
@@ -405,7 +405,7 @@
 		border-radius: var(--radius-md);
 		border: 1px solid var(--accent);
 		background: var(--muted);
-		color: var(--primary-foreground);
+		color: var(--foreground);
 		cursor: pointer;
 		display: flex;
 		align-items: center;

--- a/src/routes/cardsboard/BoardsList.svelte
+++ b/src/routes/cardsboard/BoardsList.svelte
@@ -305,6 +305,7 @@
         >
             <MenuIcon class="h-5 w-5" />
         </Button>
+        <div class="flex-1">Board Einstellungen</div>
     </div>
     
     <!-- Expandable Menu -->

--- a/src/routes/cardsboard/BoardsList.svelte
+++ b/src/routes/cardsboard/BoardsList.svelte
@@ -41,7 +41,7 @@
     import LiaScriptExportDialog from '$lib/components/LiaScriptExportDialog.svelte';
     import PublishToEdufeedDialog from './PublishToEdufeedDialog.svelte';
     import SendIcon from '@lucide/svelte/icons/send';
-    import { PackageOpenIcon } from 'lucide-svelte';
+    import PackageOpenIcon from '@lucide/svelte/icons/package-open';
 
     // Props
     let { 
@@ -303,7 +303,7 @@
     
     <!-- Expandable Menu (Dropdown-Style) -->
     {#if hamburgerMenuOpen}
-        <div transition:slide={{ duration: 200 }} class="bg-muted/50 border-b -mx-2 -mt-2 mb-1 max-h-[60vh] overflow-y-auto">
+        <div transition:slide={{ duration: 200 }} class="bg-muted/50 border-b -mx-2 -mt-2 mb-1 max-h-[60vh] overflow-y-auto editor-menu bg-[var(--card)]">
             <!-- 1. Eigenschaften (Board Settings) -->
             <MenuItem 
                 icon={PackageOpenIcon} 
@@ -599,7 +599,7 @@
         </div>
     {/if}
     
-    <h2 class="text-m font-semibold text-center upper">Meine Boards</h2>
+    <h2 class="text-lg font-semibold upper">Meine Boards</h2>
 
     <div class="m-2 flex-shrink-0">
         <div class="relative">

--- a/src/routes/cardsboard/BoardsList.svelte
+++ b/src/routes/cardsboard/BoardsList.svelte
@@ -301,9 +301,9 @@
 
 <div class="flex flex-col gap-3 h-full overflow-hidden p-2">
     
-    <!-- Expandable Menu -->
+    <!-- Expandable Menu (Dropdown-Style) -->
     {#if hamburgerMenuOpen}
-        <div transition:slide={{ duration: 200 }} class="bg-card border rounded-md mb-2 shadow-md max-h-[60vh] overflow-y-auto">
+        <div transition:slide={{ duration: 200 }} class="bg-muted/50 border-b -mx-2 -mt-2 mb-1 max-h-[60vh] overflow-y-auto">
             <!-- 1. Eigenschaften (Board Settings) -->
             <MenuItem 
                 icon={PackageOpenIcon} 

--- a/src/routes/cardsboard/BoardsList.svelte
+++ b/src/routes/cardsboard/BoardsList.svelte
@@ -41,15 +41,21 @@
     import LiaScriptExportDialog from '$lib/components/LiaScriptExportDialog.svelte';
     import PublishToEdufeedDialog from './PublishToEdufeedDialog.svelte';
     import SendIcon from '@lucide/svelte/icons/send';
+    import { PackageOpenIcon } from 'lucide-svelte';
 
     // Props
-    let { currentBoardId = '' }: { currentBoardId?: string } = $props();
+    let { 
+        currentBoardId = '', 
+        hamburgerMenuOpen = $bindable(false)
+    }: { 
+        currentBoardId?: string;
+        hamburgerMenuOpen?: boolean;
+    } = $props();
 
     // State
     let searchQuery = $state('');
     let isCreating = $state(false);
     let isLoading = $state(false);
-    let hamburgerMenuOpen = $state(false);
     
     // Board Settings Dialog State
     let settingsDialogOpen = $state(false);
@@ -294,26 +300,13 @@
 </script>
 
 <div class="flex flex-col gap-3 h-full overflow-hidden p-2">
-    <!-- Hamburger Menu Header -->
-    <div class="flex items-center gap-2 mb-2">
-        <Button
-            variant="ghost"
-            size="icon"
-            class="h-9 w-9"
-            title="Menü"
-            onclick={() => { hamburgerMenuOpen = !hamburgerMenuOpen; }}
-        >
-            <MenuIcon class="h-5 w-5" />
-        </Button>
-        <div class="flex-1">Board Einstellungen</div>
-    </div>
     
     <!-- Expandable Menu -->
     {#if hamburgerMenuOpen}
         <div transition:slide={{ duration: 200 }} class="bg-card border rounded-md mb-2 shadow-md max-h-[60vh] overflow-y-auto">
             <!-- 1. Eigenschaften (Board Settings) -->
             <MenuItem 
-                icon={SettingsIcon} 
+                icon={PackageOpenIcon} 
                 label="Eigenschaften" 
                 onclick={() => { 
                     settingsDialogOpen = true;

--- a/src/routes/cardsboard/CardDetailsDialog.svelte
+++ b/src/routes/cardsboard/CardDetailsDialog.svelte
@@ -24,6 +24,7 @@
 	import XIcon from '@lucide/svelte/icons/x';
 	import LinkIcon from '@lucide/svelte/icons/link';
 	import ImageIcon from '@lucide/svelte/icons/image';
+	import BrainIcon from '@lucide/svelte/icons/brain';
 	import OerImagePicker from '$lib/components/OerImagePicker.svelte';
 	import { onMount, onDestroy } from 'svelte';
 	import { fade, slide } from 'svelte/transition';
@@ -122,6 +123,35 @@
 		}
 		return null;
 	});
+
+	// Finde die Spalte für diese Karte (für AI-Kontext)
+	let currentColumn = $derived.by(() => {
+		for (const col of boardStore.uiData) {
+			const found = col.items.find(c => String(c.id) === String(cardId));
+			if (found) return col;
+		}
+		return null;
+	});
+
+	/**
+	 * Fügt die Karte zum AI-Kontext hinzu (für Mobile Alternative)
+	 */
+	function handleAddToAIContext() {
+		if (!currentCard || !currentColumn) return;
+		
+		const event = new CustomEvent('addCardToAIContext', {
+			detail: {
+				cardId: String(currentCard.id),
+				cardName: currentCard.name,
+				columnId: currentColumn.id,
+				columnName: currentColumn.name
+			}
+		});
+		window.dispatchEvent(event);
+		
+		// Optional: Dialog schließen nach Hinzufügen
+		// open = false;
+	}
 
 	// Abgeleitete Werte
 	let displayComments = $derived(currentCard?.comments || []);
@@ -455,6 +485,17 @@
 				/>
 				<div class="flex items-center gap-1 flex-shrink-0">
 					{#if !readOnly}
+					<!-- AI-Kontext Button (besonders nützlich für Mobile) -->
+					<Button 
+						variant="ghost" 
+						size="sm"
+						onclick={handleAddToAIContext}
+						class="h-8 w-8 p-0 text-muted-foreground hover:text-primary hover:bg-primary/10"
+						aria-label="Zum AI-Kontext hinzufügen"
+						title="Zum AI-Kontext hinzufügen"
+					>
+						<BrainIcon class="h-4 w-4" />
+					</Button>
 					<Button 
 						variant="ghost" 
 						size="sm"

--- a/src/routes/cardsboard/Column.svelte
+++ b/src/routes/cardsboard/Column.svelte
@@ -61,6 +61,10 @@
 	let selectedColor = $state(color || 'slate');
 	let popoverOpen = $state(false);
 	
+	// State für Inline-Editing des Column-Titels
+	let isEditingTitle = $state(false);
+	let titleInputRef: HTMLInputElement | null = $state(null);
+	
 	// Global popover state management - ensures only one popover is open at a time
 	const popoverId = `column-popover-${columnId}`;
 
@@ -211,6 +215,27 @@
 				// Setze den Namen zurück
 				editName = name;
 			}
+		}
+		isEditingTitle = false;
+	}
+	
+	// Funktionen für Inline-Editing des Column-Titels
+	function startEditingColumnTitle(e: MouseEvent) {
+		if (readOnly) return;
+		e.stopPropagation();
+		editName = name;
+		isEditingTitle = true;
+		setTimeout(() => titleInputRef?.focus(), 10);
+	}
+	
+	function handleColumnTitleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Enter') {
+			e.preventDefault();
+			handleRenameChange();
+		} else if (e.key === 'Escape') {
+			e.preventDefault();
+			editName = name;
+			isEditingTitle = false;
 		}
 	}
 
@@ -380,11 +405,30 @@
 	<div class="column-header">
 		<div class="flex items-center justify-between w-full">
 			<!-- Drag Handle + Title -->
-			<div class="flex items-center gap-2 flex-1 cursor-grab active:cursor-grabbing" title="Spalte verschieben" data-dnd-handle>
-				<svg class="h-4 w-4 text-muted-foreground flex-shrink-0" fill="currentColor" viewBox="0 0 24 24">
+			<div class="flex items-center gap-2 flex-1" data-dnd-handle>
+				<svg class="h-4 w-4 text-muted-foreground flex-shrink-0 cursor-grab active:cursor-grabbing" fill="currentColor" viewBox="0 0 24 24" title="Spalte verschieben">
 					<path d="M9 3h2v2H9V3zm0 4h2v2H9V7zm0 4h2v2H9v-2zm0 4h2v2H9v-2zm0 4h2v2H9v-2zm4-16h2v2h-2V3zm0 4h2v2h-2V7zm0 4h2v2h-2v-2zm0 4h2v2h-2v-2zm0 4h2v2h-2v-2z"/>
 				</svg>
-				<div class="column-title">{name}</div>
+				{#if isEditingTitle && !readOnly}
+					<input
+						bind:this={titleInputRef}
+						bind:value={editName}
+						onblur={handleRenameChange}
+						onkeydown={handleColumnTitleKeydown}
+						onpointerdown={(e) => e.stopPropagation()}
+						class="column-title bg-transparent border-b-2 border-primary outline-none px-1 min-w-[80px]"
+					/>
+				{:else}
+					<button
+						onclick={startEditingColumnTitle}
+						onpointerdown={(e) => e.stopPropagation()}
+						class="column-title hover:bg-muted/50 px-1 rounded cursor-text transition-colors text-left"
+						title={readOnly ? name : "Klicken zum Bearbeiten"}
+						disabled={readOnly}
+					>
+						{name}
+					</button>
+				{/if}
 			</div>
 			
 			<!-- Header Toolbar: Menu (click-only, no drag) -->

--- a/src/routes/cardsboard/Column.svelte
+++ b/src/routes/cardsboard/Column.svelte
@@ -406,7 +406,8 @@
 		<div class="flex items-center justify-between w-full">
 			<!-- Drag Handle + Title -->
 			<div class="flex items-center gap-2 flex-1" data-dnd-handle>
-				<svg class="h-4 w-4 text-muted-foreground flex-shrink-0 cursor-grab active:cursor-grabbing" fill="currentColor" viewBox="0 0 24 24" title="Spalte verschieben">
+				<svg class="h-4 w-4 text-muted-foreground flex-shrink-0 cursor-grab active:cursor-grabbing" fill="currentColor" viewBox="0 0 24 24" aria-label="Spalte verschieben">
+					<title>Spalte verschieben</title>
 					<path d="M9 3h2v2H9V3zm0 4h2v2H9V7zm0 4h2v2H9v-2zm0 4h2v2H9v-2zm0 4h2v2H9v-2zm4-16h2v2h-2V3zm0 4h2v2h-2V7zm0 4h2v2h-2v-2zm0 4h2v2h-2v-2zm0 4h2v2h-2v-2z"/>
 				</svg>
 				{#if isEditingTitle && !readOnly}

--- a/src/routes/cardsboard/LeftSidebarFooter.svelte
+++ b/src/routes/cardsboard/LeftSidebarFooter.svelte
@@ -11,6 +11,7 @@
 	import LogInIcon from "@lucide/svelte/icons/log-in";
 	import LogOutIcon from "@lucide/svelte/icons/log-out";
 	import PlayIcon from "@lucide/svelte/icons/play";
+	import UserIcon from "@lucide/svelte/icons/user";
 	import { ProfileEditor } from '$lib/components/auth/index.js';
 
 
@@ -83,6 +84,14 @@
 					</DropdownMenu.Trigger>
 
 					<DropdownMenu.Content align="start" class="w-56">
+						
+						<!-- Profil bearbeiten -->
+						<DropdownMenu.Item onclick={() => showProfileEditor = true} class="gap-2">
+							<UserIcon class="h-4 w-4" />
+							<span>Profil bearbeiten</span>
+						</DropdownMenu.Item>
+						
+						<DropdownMenu.Separator />
 						
 						<!-- Logout -->
 						<DropdownMenu.Item onclick={handleLogout} class="gap-2 destructive menu-item">

--- a/src/routes/cardsboard/MenuItem.svelte.d.ts
+++ b/src/routes/cardsboard/MenuItem.svelte.d.ts
@@ -1,0 +1,13 @@
+import type { Component } from 'svelte';
+interface Props {
+    icon: Component;
+    label: string;
+    onclick: () => void;
+    disabled?: boolean;
+    showBorder?: boolean;
+    showChevron?: boolean;
+    variant?: 'default' | 'danger';
+}
+declare const MenuItem: Component<Props, {}, "">;
+type MenuItem = ReturnType<typeof MenuItem>;
+export default MenuItem;

--- a/src/routes/cardsboard/Topbar.svelte
+++ b/src/routes/cardsboard/Topbar.svelte
@@ -7,11 +7,18 @@
     import { boardStore } from '$lib/stores/kanbanStore.svelte.js';
     import { BotIcon } from 'lucide-svelte';
     import PublishToEdufeedDialog from './PublishToEdufeedDialog.svelte';
-  import { onMount } from 'svelte';
-  import { settingsStore } from '$lib/stores/settingsStore.svelte';
+    import { onMount } from 'svelte';
+    import { settingsStore } from '$lib/stores/settingsStore.svelte';
+    import { toast } from 'svelte-sonner';
+    import PencilIcon from '@lucide/svelte/icons/pencil';
     
     // State für Edufeed-Dialog
     let showEdufeedDialog = $state(false);
+    
+    // State für Inline-Editing des Board-Titels
+    let isEditingTitle = $state(false);
+    let editTitleValue = $state('');
+    let titleInputRef: HTMLInputElement | null = $state(null);
 	
     // Props für Sidebar-Toggle, Title und Board-Meta
     let {
@@ -84,6 +91,42 @@
     onMount(() => {
         settingsStore.setTheme(settingsStore.settings.theme);
     })
+    
+    // Funktionen für Inline-Editing des Board-Titels
+    function startEditingTitle() {
+        editTitleValue = currentBoardTitle;
+        isEditingTitle = true;
+        // Focus auf Input nach dem Rendern
+        setTimeout(() => titleInputRef?.focus(), 10);
+    }
+    
+    function saveTitle() {
+        if (editTitleValue.trim() && editTitleValue !== currentBoardTitle) {
+            try {
+                boardStore.updateCurrentBoardMeta({ name: editTitleValue.trim() });
+                toast.success('Board-Titel gespeichert');
+            } catch (error) {
+                console.error('❌ Fehler beim Speichern des Titels:', error);
+                toast.error('Titel konnte nicht gespeichert werden');
+            }
+        }
+        isEditingTitle = false;
+    }
+    
+    function cancelEditTitle() {
+        isEditingTitle = false;
+        editTitleValue = currentBoardTitle;
+    }
+    
+    function handleTitleKeydown(e: KeyboardEvent) {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            saveTitle();
+        } else if (e.key === 'Escape') {
+            e.preventDefault();
+            cancelEditTitle();
+        }
+    }
 </script>
 
 <header class="sticky top-0 z-50 w-full max-w-full border-b-4 shrink-0 overflow-x-auto">
@@ -109,7 +152,25 @@
             
             <!-- 🔥 WICHTIG: Zeige Titel direkt vom Store an, nicht über Props! -->
             <div class="hidden md:flex items-baseline gap-1">
-                <span class="font-semibold text-lg">{currentBoardTitle}</span>
+                {#if isEditingTitle}
+                    <input
+                        bind:this={titleInputRef}
+                        bind:value={editTitleValue}
+                        onblur={saveTitle}
+                        onkeydown={handleTitleKeydown}
+                        class="font-semibold text-lg bg-transparent border-b-2 border-primary outline-none px-1 min-w-[150px] max-w-[400px]"
+                        style="width: {Math.max(150, editTitleValue.length * 10)}px"
+                    />
+                {:else}
+                    <button
+                        onclick={startEditingTitle}
+                        class="font-semibold text-lg hover:bg-muted px-1 rounded cursor-text transition-colors group flex items-center gap-1"
+                        title="Klicken zum Bearbeiten"
+                    >
+                        {currentBoardTitle}
+                        <PencilIcon class="h-3 w-3 opacity-0 group-hover:opacity-50 transition-opacity" />
+                    </button>
+                {/if}
                 
                 <!-- CC License Badge (superscript style) -->
                 {#if currentBoardLicense}

--- a/src/routes/cardsboard/Topbar.svelte
+++ b/src/routes/cardsboard/Topbar.svelte
@@ -150,7 +150,14 @@
             
             <Separator orientation="vertical" class="min-w-4 hidden sm:block" />
             
-            <!-- 🔥 WICHTIG: Zeige Titel direkt vom Store an, nicht über Props! -->
+            <!-- Mobile: Kompakter Titel (Menü ist in der Sidebar) -->
+            {#if isMobile}
+                <span class="font-semibold text-sm truncate max-w-[150px]">
+                    {currentBoardTitle}
+                </span>
+            {/if}
+            
+            <!-- Desktop: Voller Titel mit Inline-Editing -->
             <div class="hidden md:flex items-baseline gap-1">
                 {#if isEditingTitle}
                     <input

--- a/src/routes/cardsboard/Topbar.svelte
+++ b/src/routes/cardsboard/Topbar.svelte
@@ -141,7 +141,8 @@
                 class="h-8 w-8 bg-secondary"
             >
                 {#if isMobile}
-                    <MenuIcon class="h-4 w-4" />
+                    <!-- <MenuIcon class="h-4 w-4" /> -->
+                    <PanelLeftIcon class="h-4 w-4" />
                 {:else}
                     <PanelLeftIcon class="h-4 w-4" />
                 {/if}
@@ -152,7 +153,7 @@
             
             <!-- Mobile: Kompakter Titel (Menü ist in der Sidebar) -->
             {#if isMobile}
-                <span class="font-semibold text-sm truncate max-w-[150px]">
+                <span class="font-semibold text-sm truncate max-w-[150px] pl-2">
                     {currentBoardTitle}
                 </span>
             {/if}

--- a/src/routes/cardsboard/Topbar.svelte
+++ b/src/routes/cardsboard/Topbar.svelte
@@ -203,7 +203,7 @@
         <!-- Right Section: Actions + Right Sidebar Trigger -->
         <div class="flex items-center gap-0.5 sm:gap-2">
             <!-- Mobile: Icon-only Button -->
-            <Button
+            <!-- <Button
                 variant="outline"
                 size="icon"
                 onclick={() => showEdufeedDialog = true}
@@ -211,7 +211,7 @@
                 title="Board als OER zu Edufeed teilen"
             >
                 <ShareIcon class="h-4 w-4" />
-            </Button>
+            </Button> -->
             
             <Separator orientation="vertical" class="min-w-0.5 sm:min-w-3" />
             

--- a/src/routes/cardsboard/Topbar.svelte
+++ b/src/routes/cardsboard/Topbar.svelte
@@ -129,7 +129,7 @@
     }
 </script>
 
-<header class="sticky top-0 z-50 w-full max-w-full border-b-4 shrink-0 overflow-x-auto">
+<header class="sticky top-0 z-50 w-full max-w-full border-b-2 shrink-0 overflow-x-auto">
     <div class="flex h-14 items-center justify-between gap-0.5 sm:gap-2 px-1.5 sm:px-4 min-w-max">
         <!-- Left Section: Sidebar Trigger + Logo -->
         <div class="flex items-center gap-0.5 sm:gap-2">


### PR DESCRIPTION
# Pull Request: Inline-Editing & Mobile UX Verbesserungen

## 🎯 Zusammenfassung

Dieser PR implementiert Inline-Editing für Board- und Spaltentitel sowie verschiedene UX-Verbesserungen für die Desktop- und Mobile-Ansicht des Kanban-Boards.

## 📋 Änderungsübersicht

| Datei | Änderungen |
|-------|------------|
| `src/routes/cardsboard/Column.svelte` | +51 Zeilen - Inline-Editing für Spaltentitel |
| `src/routes/cardsboard/Topbar.svelte` | +85 Zeilen - Inline-Editing für Board-Titel |
| `src/routes/cardsboard/+page.svelte` | +48/-91 Zeilen - Sidebar-Refactoring, AI-Kontext-Handler |
| `src/routes/cardsboard/BoardsList.svelte` | +30 Zeilen - Hamburger-Menü, UI-Optimierungen |
| `src/routes/cardsboard/AIPanel.svelte` | Refactoring zu globalem Store |
| `src/routes/cardsboard/CardDetailsDialog.svelte` | +41 Zeilen - AI-Kontext-Button |
| `src/routes/cardsboard/LeftSidebarFooter.svelte` | +9 Zeilen - Profilbearbeitungsoption |
| `src/lib/stores/aiContextStore.svelte.ts` | +69 Zeilen - **Neuer Store** |
| `src/app.css` | +11 Zeilen - Styling-Anpassungen |

**Gesamt: +402 Zeilen, -139 Zeilen (11 Dateien)**

---

## ✨ Neue Features

### 1. Inline-Editing für Board-Titel (Topbar.svelte)
- **Desktop**: Klick auf Board-Titel startet Inline-Editing
- Stift-Icon erscheint bei Hover als visueller Hinweis
- Enter speichert, Escape bricht ab
- Toast-Benachrichtigung bei erfolgreichem Speichern
- Dynamische Input-Breite passt sich Textlänge an

### 2. Inline-Editing für Spaltentitel (Column.svelte)
- Klick auf Spaltentitel startet Inline-Editing
- Separater Drag-Handle verhindert Konflikte mit DnD
- Enter speichert, Escape bricht ab
- Read-Only-Modus wird respektiert
- Pointer-Events werden korrekt gestoppt

### 3. Globaler AI-Kontext-Store (aiContextStore.svelte.ts)
**Problem**: Beim Schließen der rechten Sidebar (Mobile) gingen ausgewählte Kontext-Karten verloren.

**Lösung**: Neuer globaler Store für AI-Kontext-Karten:
```typescript
aiContextStore.addCard(card)    // Karte hinzufügen (mit Duplikat-Prüfung)
aiContextStore.removeCard(id)   // Karte entfernen
aiContextStore.clear()          // Alle entfernen
aiContextStore.cards            // Alle Karten abrufen
```

### 4. AI-Kontext-Button in CardDetailsDialog
- Neuer 🧠 Brain-Button im Dialog-Header
- Alternative zu CTRL+Klick / Long-Press für Mobile
- Long-Press auf Mobile kollidiert mit Drag-and-Drop
- Toast-Feedback beim Hinzufügen

### 5. Hamburger-Menü für Board-Einstellungen
- Neues Menü in der linken Sidebar-Header
- Zentraler Zugang zu Board-Einstellungen
- Konsistentes Styling mit `bg-muted/80`

### 6. Profilbearbeitungsoption in User-Dropdown
- Neuer "Profil bearbeiten" Eintrag mit User-Icon
- Trenner vor "Abmelden"
- Öffnet ProfileEditor-Dialog

---

## 🔧 Technische Änderungen

### Sidebar-Architektur vereinfacht
- Entfernung der redundanten `leftSidebarSize`/`rightSidebarSize` States
- Einfache Boolean-Toggle-Logik
- Desktop: Resizable Panes mit fixer linker Sidebar
- Mobile: Sheet-basierte Sidebars

### Event-Handler-Architektur
- `addCardToAIContext`-Event wird jetzt global in `+page.svelte` gehandhabt
- Funktioniert auch bei geschlossener AI-Sidebar
- Event-Listener in `AIPanel.svelte` entfernt (vermeidet Duplikate)

### Styling-Verbesserungen
- Border-Dicke reduziert: `border-b-4` → `border-b-2`
- Konsistentes Hover-Styling für editierbare Elemente
- Mobile-optimierte Titel-Anzeige (truncate mit max-width)

---

## 🧪 Testhinweise

### Inline-Editing testen
1. Board-Titel in Topbar klicken → Input erscheint
2. Neuen Namen eingeben → Enter drücken
3. Toast "Board-Titel gespeichert" erscheint
4. Spalten-Titel klicken → Input erscheint
5. Escape drücken → Änderung verwerfen

### AI-Kontext testen (Mobile)
1. Mobile-Ansicht aktivieren (< 768px)
2. Rechte Sidebar schließen
3. Karte öffnen → 🧠 Button klicken
4. Toast zeigt "zum KI-Kontext hinzugefügt"
5. Rechte Sidebar öffnen → Karte ist im Kontext

### Hamburger-Menü testen
1. Hamburger-Icon in linker Sidebar klicken
2. Dropdown-Menü erscheint mit Board-Einstellungen
3. Menü-Hintergrund ist `bg-muted/80`

---

## 📝 Breaking Changes

Keine. Alle Änderungen sind abwärtskompatibel.

---

## 📚 Dokumentations-Updates

- [x] ROADMAP.md aktualisieren (Phase 2: UI Components → 20% Complete)
- [x] CHANGELOG.md Eintrag hinzufügen (v4.7.25)
- [x] Manual: Inline-Editing dokumentieren (`docs/GUIDES/INLINE-EDITING.md`)

---

## 🔗 Verwandte Issues

- Verbesserte Mobile-UX für AI-Integration
- Schnellere Board-Bearbeitung ohne Dialoge

---

## ✅ Checkliste

- [x] Code kompiliert ohne Fehler (`pnpm check` ✓)
- [x] Keine TypeScript-Fehler
- [x] UI funktioniert auf Desktop
- [x] UI funktioniert auf Mobile
- [x] Keine Regression bei DnD
- [x] Event-Listener korrekt aufgeräumt (onDestroy)

---

## 📸 Screenshots

*TODO: Screenshots von Inline-Editing und Mobile AI-Kontext-Button hinzufügen*

---

## Commits in diesem PR

1. `b55ce9a` - feat: Implementiere Inline-Editing für Spalten- und Board-Titel
2. `2af43c9` - feat: Fix Farbgebung Add Column Button und füge Beschriftung hinzu
3. `82d12eb` - feat: Füge Titel und Icon für EduFeed Kanban-Editor ein
4. `62e97f0` - feat: Implementiere Hamburger-Menü für Board-Einstellungen
5. `d49501b` - feat: Verbessere das Layout der linken Sidebar
6. `1c12ea2` - feat: Optimiere das Styling und die Interaktivität
7. `850bc7b` - feat: Optimiere Sidebar-/Topbar-Stile, füge Profilbearbeitung hinzu
8. `572d65f` - feat: Kommentiere Button für Teilen zu Edufeed aus
9. `932da18` - feat: Implementiere globalen AI-Kontext-Store

---

**Branch:** `inline-editing`  
**Base:** `cardsboard`  
**Datum:** 31. Januar 2026
