### PR TITLE
Fix Reload-Stabilität für Fremd-Boards & Permalinks

### DIFF
--- a/src/lib/stores/followBoardState.svelte.ts
+++ b/src/lib/stores/followBoardState.svelte.ts
@@ -1,0 +1,46 @@
+/**
+ * Reactive state for "follow / import foreign board" CTA in Topbar.
+ *
+ * Set by [naddr]/+page.svelte when a foreign (viewer-only) board is loaded.
+ * Read by Topbar.svelte to show a discreet "Speichern" action-button.
+ *
+ * Lifecycle:
+ *   [naddr]/+page loads board → setPending()  → Topbar shows button
+ *   User clicks button         → requestOpen() → naddr page opens FollowBoardDialog
+ *   User navigates away        → clear()       → button disappears
+ */
+class FollowBoardState {
+    boardId     = $state<string | null>(null);
+    boardAuthor = $state<string | null>(null);
+
+    /** True if shouldOpen was set by requestOpen() and the page hasn't consumed it yet */
+    shouldOpen = $state(false);
+
+    /** True when a foreign board is currently displayed (follow CTA available) */
+    get hasPending(): boolean {
+        return this.boardId !== null;
+    }
+
+    /** Called by [naddr]/+page after loading a foreign board as viewer */
+    setPending(boardId: string, boardAuthor: string): void {
+        this.boardId     = boardId;
+        this.boardAuthor = boardAuthor;
+        this.shouldOpen  = false;
+    }
+
+    /** Called by Topbar button — the naddr page $effect picks this up and opens the dialog */
+    requestOpen(): void {
+        if (this.boardId) {
+            this.shouldOpen = true;
+        }
+    }
+
+    /** Called by onDestroy in [naddr]/+page when user navigates away */
+    clear(): void {
+        this.boardId     = null;
+        this.boardAuthor = null;
+        this.shouldOpen  = false;
+    }
+}
+
+export const followBoardState = new FollowBoardState();

--- a/src/lib/stores/kanbanStore.svelte.ts
+++ b/src/lib/stores/kanbanStore.svelte.ts
@@ -875,6 +875,21 @@ export class BoardStore {
                         console.log(`✅ Re-loading current board without lastAccessed update: ${currentId}`);
                         this.loadBoard(currentId, { skipLastAccessed: true });
                     } else {
+                        // ⚡ Guard: Wenn das aktuelle Board in localStorage existiert, wurde es bewusst
+                        // geladen (Viewer-Board via naddr, noch nicht publiziertes eigenes Board, etc.).
+                        // Kein Auto-Switch – der User sieht dieses Board absichtlich.
+                        //
+                        // Tombstoned Boards können hier nicht auftauchen: loadBoard() blockt sie bereits.
+                        // Deleted-via-Nostr-Event Boards werden separat via handleDeletionEvent tombstoned.
+                        //
+                        // Warum NICHT cachedSharedBoards prüfen: onAuthChanged() löscht diesen Cache
+                        // beim App-Start → Race Condition mit dem naddr-Page Load.
+                        if (BoardStorage.loadBoard(currentId)) {
+                            console.log(`✅ loadBoardsFromNostr: Board ${currentId} lokal vorhanden, kein Auto-Switch (Viewer/Foreign Board)`);
+                            this.updateTrigger++;
+                            return;
+                        }
+
                         // Aktuelles Board wurde gelöscht → Lade das neueste Board
                         const allBoards = this.getAllBoards();
                         if (allBoards.length > 0) {

--- a/src/lib/stores/kanbanStore.svelte.ts
+++ b/src/lib/stores/kanbanStore.svelte.ts
@@ -3053,6 +3053,8 @@ export class BoardStore {
      * Prüft ob der aktuelle Nutzer Editor-Rechte hat
      */
     public canCurrentUserEdit(): boolean {
+        // 🎯 DEMO-BOARD EXCEPTION: Anonyme Benutzer dürfen alles im Demo-Board
+        if (this.board.id === 'demo-board') return true;
         const currentUser = authStore.getPubkey();
         return this.board.canEditBoard(currentUser || undefined);
     }

--- a/src/routes/cardsboard/+layout.svelte
+++ b/src/routes/cardsboard/+layout.svelte
@@ -1,0 +1,322 @@
+<script lang="ts">
+/**
+ * Shared Layout für /cardsboard/ und /cardsboard/[naddr]/
+ * Enthält: Topbar, Left Sidebar (BoardsList), Right Sidebar (AI), Board-Rendering
+ * Child-Pages liefern nur Overlays/Dialogs via {@render children()}
+ */
+import { onMount, onDestroy } from 'svelte';
+import Board from "./Board.svelte";
+import BoardsList from "./BoardsList.svelte";
+import LeftSidebarFooter from "./LeftSidebarFooter.svelte";
+import Topbar from "./Topbar.svelte";
+import AIPanel from "./AIPanel.svelte";
+import type { Column } from "./types.js";
+import * as Resizable from "$lib/components/ui/resizable/index.js";
+import * as Sheet from "$lib/components/ui/sheet/index.js";
+import { Button } from "$lib/components/ui/button/index.js";
+import { boardStore } from "$lib/stores/kanbanStore.svelte.js";
+import { aiContextStore, type ContextCard } from '$lib/stores/aiContextStore.svelte.js';
+import { showEditorPermissionToast } from '$lib/utils/permissionToast';
+import { toast } from "svelte-sonner";
+import MenuIcon from '@lucide/svelte/icons/menu';
+
+let { children } = $props();
+
+// Hamburger Menu State für Board-Einstellungen
+let hamburgerMenuOpen = $state(false);
+
+// Mobile detection (screens < 768px are considered mobile)
+let isMobile = $state(false);
+
+// ==========================================================================
+// GLOBAL AI CONTEXT EVENT HANDLER
+// Muss global sein, damit es auch funktioniert wenn AIPanel geschlossen ist
+// ==========================================================================
+function handleGlobalAddCardToContext(e: CustomEvent<ContextCard>) {
+	const newCard = e.detail;
+	const added = aiContextStore.addCard(newCard);
+	if (added) {
+		toast.success(`"${newCard.cardName}" zum KI-Kontext hinzugefügt`);
+	} else {
+		toast.info(`Karte ist bereits im KI-Kontext`);
+	}
+}
+
+// ============================================================================
+// LIFECYCLE: ONMOUNT HOOKS (Browser API calls - only once per component mount)
+// ============================================================================
+
+// Hook 0: Globaler Event-Listener für AI-Kontext (funktioniert auch bei geschlossener Sidebar)
+onMount(() => {
+	window.addEventListener('addCardToAIContext', handleGlobalAddCardToContext as EventListener);
+});
+
+onDestroy(() => {
+	if (typeof window !== 'undefined') {
+		window.removeEventListener('addCardToAIContext', handleGlobalAddCardToContext as EventListener);
+	}
+});
+
+// Hook 1: Suppress passive event listener warnings for dnd-action
+// ✅ CORRECT: onMount for one-time side effects
+onMount(() => {
+	const originalWarn = console.warn;
+	console.warn = function(...args: any[]) {
+		const message = String(args[0] || '');
+		if (message.includes('non-passive event listener') ||
+			message.includes('Added non-passive event listener') ||
+			message.includes('scroll-blocking') ||
+			message.includes('touchstart') ||
+			message.includes('touchmove')) {
+			return;
+		}
+		originalWarn.apply(console, args);
+	};
+});
+
+// Hook 4: Mobile detection and responsive listener
+onMount(() => {
+	const checkMobile = () => {
+		isMobile = window.innerWidth < 768;
+	};
+	
+	// Initial check
+	checkMobile();
+	
+	// Listen for resize events
+	window.addEventListener('resize', checkMobile);
+	
+	// Cleanup
+	return () => {
+		window.removeEventListener('resize', checkMobile);
+	};
+});
+
+// Konvertiere boardStore.uiData in das Format, das Board.svelte erwartet
+let columns = $derived.by(() => {
+	return boardStore.uiData;
+});
+
+// Aktuelles Board Meta
+let currentBoardId = $derived(boardStore.getCurrentBoardId());
+
+// 🔥 WICHTIG: Direkter reaktiver Zugriff für Topbar!
+// Damit Svelte erkennt, dass sich der Titel geändert hat
+let boardTitle = $derived(boardStore.getCurrentBoardMeta().name);
+
+// Auto-load comments reactively when board changes
+let lastCommentLoadBoardId = '';
+$effect(() => {
+	const bid = currentBoardId;
+	if (bid && bid !== lastCommentLoadBoardId) {
+		lastCommentLoadBoardId = bid;
+		boardStore.loadAllComments()
+			.then(() => console.log('✅ All comments loaded'))
+			.catch((err: unknown) => console.error('❌ Error loading comments:', err));
+	}
+});
+
+// Background subscriptions for comment live updates across the whole board
+let unsubscribeAllComments: (() => void) | null = null;
+$effect(() => {
+	const boardId = currentBoardId;
+	if (!boardId) return;
+
+	unsubscribeAllComments?.();
+	unsubscribeAllComments = boardStore.subscribeToAllComments();
+
+	return () => {
+		unsubscribeAllComments?.();
+		unsubscribeAllComments = null;
+	};
+});
+
+// Debounce-State für Toast-Benachrichtigungen
+let lastToastTime = 0;
+const TOAST_DEBOUNCE_MS = 1000; // 1 Sekunde
+
+function handleBoardUpdated(newColumnsData: Column[]) {
+	// Synchronisiere kompletten Board-State: Spalten UND Karten-Positionen
+	console.log('📋 handleBoardUpdated - Synchronisiere Board-State');
+	const success = boardStore.syncBoardState(newColumnsData);
+	
+	// Wenn keine Berechtigung: Zeige Toast-Warnung (mit Debounce)
+	if (!success) {
+		const now = Date.now();
+		// Zeige Toast nur, wenn letzter Toast > 1 Sekunde her ist
+		if (now - lastToastTime > TOAST_DEBOUNCE_MS) {
+			showEditorPermissionToast(
+				'Du brauchst Editorrechte, um Änderungen durchzuführen.'
+			);
+			lastToastTime = now;
+		} else {
+			console.log('⏭️ Toast übersprungen (Debounce)');
+		}
+	}
+}
+
+// Debug Stats
+let stats = $derived({
+	columnsCount: columns.length,
+	cardsCount: columns.reduce((sum: number, col: any) => sum + col.items.length, 0)
+});
+
+// Sidebar states
+let leftSidebarOpen = $state(true);
+let rightSidebarOpen = $state(false);
+
+// Auto-close left sidebar on mobile
+$effect(() => {
+	if (isMobile) {
+		leftSidebarOpen = false;
+	}
+});
+
+// Toggle-Funktionen
+function toggleLeftSidebar() {
+	leftSidebarOpen = !leftSidebarOpen;
+}
+
+function toggleRightSidebar() {
+	rightSidebarOpen = !rightSidebarOpen;
+}
+</script>
+
+<style>
+	/* Verhindere jegliches Scrolling auf der Seite */
+	:global(html, body) {
+		overflow: hidden !important;
+		height: 100vh;
+	}
+</style>
+
+<div class="flex h-screen w-full flex-col overflow-hidden">
+	
+	{#if isMobile}
+		<!-- Mobile Layout: Sidebars as overlay sheets -->
+		<main class="flex flex-1 flex-col overflow-hidden">
+			<Topbar
+				onToggleLeftSidebar={toggleLeftSidebar}
+				onToggleRightSidebar={toggleRightSidebar}
+				{isMobile}
+			/>
+			
+			<div class="flex-1 overflow-hidden p-0 min-h-0">
+				<Board 
+					columns={columns} 
+					onFinalUpdate={handleBoardUpdated}
+				/>
+			</div>
+		</main>
+		
+		<!-- Left Sidebar Sheet (Mobile) -->
+		<Sheet.Root bind:open={leftSidebarOpen}>
+			<Sheet.Content side="left" class="w-[280px] sm:w-[320px] p-0 [&>button]:hidden flex flex-col">
+				<!-- Header mit Titel und Menü-Button -->
+				<div class="px-4 py-3 border-b-4 flex items-center justify-between shrink-0">
+					<Button
+						variant="ghost"
+						size="icon"
+						class="h-8 w-8 hamburger-menu-button bg-primary text-primary-foreground"
+						title="Board Einstellungen"
+						onclick={() => { hamburgerMenuOpen = !hamburgerMenuOpen; }}
+					>
+						<MenuIcon class="h-4 w-4" />
+					</Button>
+					<div class="flex items-center gap-2">
+						<h2 class="font-semibold">Kanban-Editor</h2>
+					</div>
+				</div>
+				<!-- Content Bereich - flex-1 für den restlichen Platz -->
+				<div class="flex-1 flex flex-col overflow-hidden">
+					<div class="flex-1 overflow-y-auto min-h-0 p-2">
+						<BoardsList {currentBoardId} bind:hamburgerMenuOpen />
+					</div>
+					<LeftSidebarFooter />
+				</div>
+			</Sheet.Content>
+		</Sheet.Root>
+		
+		<!-- Right Sidebar Sheet (Mobile) -->
+		<Sheet.Root bind:open={rightSidebarOpen}>
+			<Sheet.Content side="right" class="w-[320px] sm:w-[380px] p-0">
+				<Sheet.Header class="p-4 border-b">
+					<Sheet.Title>KI-Assistent</Sheet.Title>
+				</Sheet.Header>
+				<AIPanel boardId={currentBoardId} />
+			</Sheet.Content>
+		</Sheet.Root>
+		
+	{:else}
+		<!-- Desktop Layout: Left sidebar fixed, Main+Right resizable -->
+		<div class="flex flex-1 overflow-hidden">
+			
+			<!-- Linke Sidebar (Board-Liste) - feste Breite, außerhalb der PaneGroup -->
+			{#if leftSidebarOpen}
+				<aside class="w-[320px] border-r-2 bg-background flex flex-col shrink-0">
+					<!-- Header mit Titel und Menü-Button -->
+					<div class="px-4 py-3 border-b-2 flex items-center justify-between shrink-0">
+						<Button
+							variant="ghost"
+							size="icon"
+							class="h-8 w-8 bg-primary text-primary-foreground hamburger-menu-button"
+							title="Board Einstellungen"
+							onclick={() => { hamburgerMenuOpen = !hamburgerMenuOpen; }}
+						>
+							<MenuIcon class="h-4 w-4" />
+						</Button>
+						<div class="flex items-center gap-2">
+							<h2 class="font-semibold">Kanban-Editor</h2>
+						</div>
+					</div>
+					<!-- Content Bereich -->
+					<div class="flex-1 flex flex-col overflow-hidden">
+						<div class="flex-1 overflow-y-auto min-h-0 p-2">
+							<BoardsList {currentBoardId} bind:hamburgerMenuOpen />
+						</div>
+						<LeftSidebarFooter />
+					</div>
+				</aside>
+			{/if}
+			
+			<!-- Main + Rechte Sidebar als separate PaneGroup -->
+			<Resizable.PaneGroup direction="horizontal" class="flex-1 overflow-hidden">
+				<!-- Hauptbereich -->
+				<Resizable.Pane defaultSize={rightSidebarOpen ? 75 : 100} minSize={50} class="flex flex-col overflow-hidden">
+					<main class="flex flex-1 flex-col overflow-hidden min-w-0">
+						<Topbar
+							onToggleLeftSidebar={toggleLeftSidebar}
+							onToggleRightSidebar={toggleRightSidebar}
+							{isMobile}
+						/>
+						
+						<div class="flex-1 overflow-hidden p-0 min-h-0">
+							<Board 
+								columns={columns} 
+								onFinalUpdate={handleBoardUpdated}
+							/>
+						</div>
+					</main>
+				</Resizable.Pane>
+				
+				{#if rightSidebarOpen}
+					<!-- Handle zwischen Main und rechter Sidebar -->
+					<Resizable.Handle withHandle />
+					
+					<!-- Rechte Sidebar (KI-Agent) - resizable -->
+					<Resizable.Pane 
+						defaultSize={25} 
+						minSize={15} 
+						maxSize={50}
+						class="bg-background border-l-2"
+					>
+						<AIPanel boardId={currentBoardId} />
+					</Resizable.Pane>
+				{/if}
+			</Resizable.PaneGroup>
+		</div>
+	{/if}
+</div>
+
+<!-- Child page content (Dialogs, Overlays, ImportPopover etc.) -->
+{@render children()}

--- a/src/routes/cardsboard/+layout.svelte
+++ b/src/routes/cardsboard/+layout.svelte
@@ -104,6 +104,14 @@ let currentBoardId = $derived(boardStore.getCurrentBoardId());
 // Damit Svelte erkennt, dass sich der Titel geändert hat
 let boardTitle = $derived(boardStore.getCurrentBoardMeta().name);
 
+// Bearbeitungsrecht: false für Viewer, anonyme Besucher und nicht-authentifizierte Nutzer
+let canEdit = $derived(boardStore.canCurrentUserEdit());
+
+// Rechte Sidebar automatisch schließen wenn kein Bearbeitungsrecht mehr
+$effect(() => {
+	if (!canEdit) rightSidebarOpen = false;
+});
+
 // Auto-load comments reactively when board changes
 let lastCommentLoadBoardId = '';
 $effect(() => {
@@ -205,6 +213,7 @@ function toggleRightSidebar() {
 				<Board 
 					columns={columns} 
 					onFinalUpdate={handleBoardUpdated}
+					readOnly={!canEdit}
 				/>
 			</div>
 		</main>
@@ -237,7 +246,8 @@ function toggleRightSidebar() {
 			</Sheet.Content>
 		</Sheet.Root>
 		
-		<!-- Right Sidebar Sheet (Mobile) -->
+<!-- Right Sidebar Sheet (Mobile) - nur für Nutzer mit Bearbeitungsrecht -->
+		{#if canEdit}
 		<Sheet.Root bind:open={rightSidebarOpen}>
 			<Sheet.Content side="right" class="w-[320px] sm:w-[380px] p-0">
 				<Sheet.Header class="p-4 border-b">
@@ -246,6 +256,7 @@ function toggleRightSidebar() {
 				<AIPanel boardId={currentBoardId} />
 			</Sheet.Content>
 		</Sheet.Root>
+		{/if}
 		
 	{:else}
 		<!-- Desktop Layout: Left sidebar fixed, Main+Right resizable -->
@@ -294,16 +305,17 @@ function toggleRightSidebar() {
 							<Board 
 								columns={columns} 
 								onFinalUpdate={handleBoardUpdated}
+								readOnly={!canEdit}
 							/>
 						</div>
 					</main>
 				</Resizable.Pane>
 				
-				{#if rightSidebarOpen}
+				{#if rightSidebarOpen && canEdit}
 					<!-- Handle zwischen Main und rechter Sidebar -->
 					<Resizable.Handle withHandle />
 					
-					<!-- Rechte Sidebar (KI-Agent) - resizable -->
+					<!-- Rechte Sidebar (KI-Agent) - resizable, nur für Nutzer mit Bearbeitungsrecht -->
 					<Resizable.Pane 
 						defaultSize={25} 
 						minSize={15} 

--- a/src/routes/cardsboard/+page.svelte
+++ b/src/routes/cardsboard/+page.svelte
@@ -1,90 +1,30 @@
 <script lang="ts">
-import { onMount, onDestroy } from 'svelte';
+/**
+ * /cardsboard/ Hauptseite
+ * 
+ * Das Board-UI (Topbar, Sidebar, Board-Komponente) wird vom gemeinsamen
+ * +layout.svelte gerendert. Diese Page handhabt nur:
+ * - Share-Link Import via ?import=<token> URL-Parameter
+ * - Share-Link Dialog via ?share=<boardId>&author=<pubkey> URL-Parameter
+ * - RequestEditorRoleDialog
+ */
+import { onMount } from 'svelte';
 import { replaceState } from '$app/navigation';
-import Board from "./Board.svelte";
-import BoardsList from "./BoardsList.svelte";
-import LeftSidebarFooter from "./LeftSidebarFooter.svelte";
-import Topbar from "./Topbar.svelte";
 import ImportPopover from "$lib/components/ImportPopover.svelte";
 import FollowBoardDialog from "$lib/components/board/FollowBoardDialog.svelte";
 import RequestEditorRoleDialog from "$lib/components/board/RequestEditorRoleDialog.svelte";
-import AIPanel from "./AIPanel.svelte";
-import type { Column } from "./types.js";
-import * as Resizable from "$lib/components/ui/resizable/index.js";
-import * as Sheet from "$lib/components/ui/sheet/index.js";
-import { Button } from "$lib/components/ui/button/index.js";
-import { boardStore } from "$lib/stores/kanbanStore.svelte.js";
-import { aiContextStore, type ContextCard } from '$lib/stores/aiContextStore.svelte.js';
-import { BoardRole } from '$lib/types/sharing';
-import { showEditorPermissionToast } from '$lib/utils/permissionToast';
 import { toast } from "svelte-sonner";
-import SquareKanbanIcon from '@lucide/svelte/icons/square-kanban';
-import MenuIcon from '@lucide/svelte/icons/menu';
-import { authStore } from '$lib';
 
 	// Reference to ImportPopover component for share-link preview
 	let importPopoverComponent: any;
-	
-	// Hamburger Menu State für Board-Einstellungen
-	let hamburgerMenuOpen = $state(false);
 	
 	// Share-Link Dialog State
 	let showFollowDialog = $state(false);
 	let shareLinkBoardId = $state<string>('');
 	let shareLinkBoardAuthor = $state<string>('');
-	
-	// Mobile detection (screens < 768px are considered mobile)
-	let isMobile = $state(false);
 
-	// ==========================================================================
-	// GLOBAL AI CONTEXT EVENT HANDLER
-	// Muss global sein, damit es auch funktioniert wenn AIPanel geschlossen ist
-	// ==========================================================================
-	function handleGlobalAddCardToContext(e: CustomEvent<ContextCard>) {
-		const newCard = e.detail;
-		const added = aiContextStore.addCard(newCard);
-		if (added) {
-			toast.success(`"${newCard.cardName}" zum KI-Kontext hinzugefügt`);
-		} else {
-			toast.info(`Karte ist bereits im KI-Kontext`);
-		}
-	}
-
-	// ============================================================================
-	// LIFECYCLE: ONMOUNT HOOKS (Browser API calls - only once per component mount)
-	// ============================================================================
-
-	// Hook 0: Globaler Event-Listener für AI-Kontext (funktioniert auch bei geschlossener Sidebar)
-	onMount(() => {
-		window.addEventListener('addCardToAIContext', handleGlobalAddCardToContext as EventListener);
-	});
-	
-	onDestroy(() => {
-		if (typeof window !== 'undefined') {
-			window.removeEventListener('addCardToAIContext', handleGlobalAddCardToContext as EventListener);
-		}
-	});
-
-	// Hook 1: Suppress passive event listener warnings for dnd-action
-	// ✅ CORRECT: onMount for one-time side effects
-	onMount(() => {
-		const originalWarn = console.warn;
-		console.warn = function(...args) {
-			const message = String(args[0] || '');
-			if (message.includes('non-passive event listener') ||
-				message.includes('Added non-passive event listener') ||
-				message.includes('scroll-blocking') ||
-				message.includes('touchstart') ||
-				message.includes('touchmove')) {
-				return;
-			}
-			originalWarn.apply(console, args);
-		};
-	});
-
-	// Hook 2: Handle share-link import via ?import=<token> parameter
+	// Handle share-link import via ?import=<token> or ?share=<boardId>&author=<pubkey> parameter
 	// ✅ CORRECT: onMount for URL parameter detection (runs ONCE)
-	// ❌ DO NOT USE $effect.root here - would re-run on every store update!
 	// ⚠️ FIX: Wait for ImportPopover component to mount before proceeding (polling mechanism)
 	onMount(async () => {
 		try {
@@ -138,270 +78,12 @@ import { authStore } from '$lib';
 			console.error('Fehler beim Verarbeiten des Import-Tokens:', e);
 		}
 	});
-
-	// Hook 3: Auto-load comments for all cards when board is ready
-	// 🚀 Phase 4B: UX Improvement - Batch-load all comments automatically
-	// ✅ CORRECT: onMount for initial data loading (runs ONCE)
-	onMount(async () => {
-		try {
-			// Wait a bit for board to be fully loaded from storage
-			// (boardStore.uiData is reactive and loads from localStorage in constructor)
-			await new Promise(resolve => setTimeout(resolve, 500));
-			
-			const boardId = boardStore.getCurrentBoardId();
-			if (boardId) {
-				console.log('🚀 Auto-loading comments for all cards in board...');
-				await boardStore.loadAllComments();
-				console.log('✅ All comments loaded automatically');
-			}
-		} catch (error) {
-			console.error('❌ Error auto-loading comments:', error);
-		}
-	});
-
-	// Hook 4: Mobile detection and responsive listener
-	onMount(() => {
-		const checkMobile = () => {
-			isMobile = window.innerWidth < 768;
-		};
-		
-		// Initial check
-		checkMobile();
-		
-		// Listen for resize events
-		window.addEventListener('resize', checkMobile);
-		
-		// Cleanup
-		return () => {
-			window.removeEventListener('resize', checkMobile);
-		};
-	});
-
-	// Konvertiere boardStore.uiData in das Format, das Board.svelte erwartet
-	let columns = $derived.by(() => {
-		return boardStore.uiData;
-	});
-
-	// Aktuelles Board Meta
-	let currentBoardId = $derived(boardStore.getCurrentBoardId());
-	
-	// 🔥 WICHTIG: Direkter reaktiver Zugriff für Topbar!
-	// Damit Svelte erkennt, dass sich der Titel geändert hat
-	let boardTitle = $derived(boardStore.getCurrentBoardMeta().name);
-
-	// Background subscriptions for comment live updates across the whole board
-	let unsubscribeAllComments: (() => void) | null = null;
-	$effect(() => {
-		const boardId = currentBoardId;
-		if (!boardId) return;
-
-		unsubscribeAllComments?.();
-		unsubscribeAllComments = boardStore.subscribeToAllComments();
-
-		return () => {
-			unsubscribeAllComments?.();
-			unsubscribeAllComments = null;
-		};
-	});
-
-	// Debounce-State für Toast-Benachrichtigungen
-	let lastToastTime = 0;
-	const TOAST_DEBOUNCE_MS = 1000; // 1 Sekunde
-
-	function handleBoardUpdated(newColumnsData: Column[]) {
-		// Synchronisiere kompletten Board-State: Spalten UND Karten-Positionen
-		console.log('📋 handleBoardUpdated - Synchronisiere Board-State');
-		const success = boardStore.syncBoardState(newColumnsData);
-		
-		// Wenn keine Berechtigung: Zeige Toast-Warnung (mit Debounce)
-		if (!success) {
-			const now = Date.now();
-			// Zeige Toast nur, wenn letzter Toast > 1 Sekunde her ist
-			if (now - lastToastTime > TOAST_DEBOUNCE_MS) {
-				showEditorPermissionToast(
-					'Du brauchst Editorrechte, um Änderungen durchzuführen.'
-				);
-				lastToastTime = now;
-			} else {
-				console.log('⏭️ Toast übersprungen (Debounce)');
-			}
-		}
-	}
-
-
-
-	// Debug Stats
-	let stats = $derived({
-		columnsCount: columns.length,
-		cardsCount: columns.reduce((sum, col) => sum + col.items.length, 0)
-	});
-
-	// Sidebar states
-	let leftSidebarOpen = $state(true);
-	let rightSidebarOpen = $state(false);
-	
-	// Auto-close left sidebar on mobile
-	$effect(() => {
-		if (isMobile) {
-			leftSidebarOpen = false;
-		}
-	});
-	
-	// Toggle-Funktionen
-	function toggleLeftSidebar() {
-		leftSidebarOpen = !leftSidebarOpen;
-	}
-	
-	function toggleRightSidebar() {
-		rightSidebarOpen = !rightSidebarOpen;
-	}
-
 </script>
-
-<style>
-	/* Verhindere jegliches Scrolling auf der Seite */
-	:global(html, body) {
-		overflow: hidden !important;
-		height: 100vh;
-	}
-</style>
-
-<div class="flex h-screen w-full flex-col overflow-hidden">
-	
-	{#if isMobile}
-		<!-- Mobile Layout: Sidebars as overlay sheets -->
-		<main class="flex flex-1 flex-col overflow-hidden">
-			<Topbar
-				onToggleLeftSidebar={toggleLeftSidebar}
-				onToggleRightSidebar={toggleRightSidebar}
-				{isMobile}
-			/>
-			
-			<div class="flex-1 overflow-hidden p-0 min-h-0">
-				<Board 
-					columns={columns} 
-					onFinalUpdate={handleBoardUpdated}
-				/>
-			</div>
-		</main>
-		
-		<!-- Left Sidebar Sheet (Mobile) -->
-		<Sheet.Root bind:open={leftSidebarOpen}>
-			<Sheet.Content side="left" class="w-[280px] sm:w-[320px] p-0 [&>button]:hidden flex flex-col">
-				<!-- Header mit Titel und Menü-Button -->
-				<div class="px-4 py-3 border-b-4 flex items-center justify-between shrink-0">
-					<Button
-						variant="ghost"
-						size="icon"
-						class="h-8 w-8 hamburger-menu-button bg-primary text-primary-foreground"
-						title="Board Einstellungen"
-						onclick={() => { hamburgerMenuOpen = !hamburgerMenuOpen; }}
-					>
-						<MenuIcon class="h-4 w-4" />
-					</Button>
-					<div class="flex items-center gap-2">
-						<!-- <SquareKanbanIcon class="h-5 w-5" /> -->
-						<h2 class="font-semibold">Kanban-Editor</h2>
-					</div>
-					
-				</div>
-				<!-- Content Bereich - flex-1 für den restlichen Platz -->
-				<div class="flex-1 flex flex-col overflow-hidden">
-					<div class="flex-1 overflow-y-auto min-h-0 p-2">
-						<BoardsList {currentBoardId} bind:hamburgerMenuOpen />
-					</div>
-					<LeftSidebarFooter />
-				</div>
-			</Sheet.Content>
-		</Sheet.Root>
-		
-		<!-- Right Sidebar Sheet (Mobile) -->
-		<Sheet.Root bind:open={rightSidebarOpen}>
-			<Sheet.Content side="right" class="w-[320px] sm:w-[380px] p-0">
-				<Sheet.Header class="p-4 border-b">
-					<Sheet.Title>KI-Assistent</Sheet.Title>
-				</Sheet.Header>
-				<AIPanel boardId={currentBoardId} />
-			</Sheet.Content>
-		</Sheet.Root>
-		
-	{:else}
-		<!-- Desktop Layout: Left sidebar fixed, Main+Right resizable -->
-		<div class="flex flex-1 overflow-hidden">
-			
-			<!-- Linke Sidebar (Board-Liste) - feste Breite, außerhalb der PaneGroup -->
-			{#if leftSidebarOpen}
-				<aside class="w-[320px] border-r-2 bg-background flex flex-col shrink-0">
-					<!-- Header mit Titel und Menü-Button -->
-					<div class="px-4 py-3 border-b-2 flex items-center justify-between shrink-0">
-						<Button
-							variant="ghost"
-							size="icon"
-							class="h-8 w-8 bg-primary text-primary-foreground hamburger-menu-button"
-							title="Board Einstellungen"
-							onclick={() => { hamburgerMenuOpen = !hamburgerMenuOpen; }}
-						>
-							<MenuIcon class="h-4 w-4" />
-						</Button>
-						<div class="flex items-center gap-2">
-							<!-- <SquareKanbanIcon class="h-5 w-5" /> -->
-							<h2 class="font-semibold">Kanban-Editor</h2>
-						</div>
-						
-					</div>
-					<!-- Content Bereich -->
-					<div class="flex-1 flex flex-col overflow-hidden">
-						<div class="flex-1 overflow-y-auto min-h-0 p-2">
-							<BoardsList {currentBoardId} bind:hamburgerMenuOpen />
-						</div>
-						<LeftSidebarFooter />
-					</div>
-				</aside>
-			{/if}
-			
-			<!-- Main + Rechte Sidebar als separate PaneGroup -->
-			<Resizable.PaneGroup direction="horizontal" class="flex-1 overflow-hidden">
-				<!-- Hauptbereich -->
-				<Resizable.Pane defaultSize={rightSidebarOpen ? 75 : 100} minSize={50} class="flex flex-col overflow-hidden">
-					<main class="flex flex-1 flex-col overflow-hidden min-w-0">
-						<Topbar
-							onToggleLeftSidebar={toggleLeftSidebar}
-							onToggleRightSidebar={toggleRightSidebar}
-							{isMobile}
-						/>
-						
-						<div class="flex-1 overflow-hidden p-0 min-h-0">
-							<Board 
-								columns={columns} 
-								onFinalUpdate={handleBoardUpdated}
-							/>
-						</div>
-					</main>
-				</Resizable.Pane>
-				
-				{#if rightSidebarOpen}
-					<!-- Handle zwischen Main und rechter Sidebar -->
-					<Resizable.Handle withHandle />
-					
-					<!-- Rechte Sidebar (KI-Agent) - resizable -->
-					<Resizable.Pane 
-						defaultSize={25} 
-						minSize={15} 
-						maxSize={50}
-						class="bg-background border-l-2"
-					>
-						<AIPanel boardId={currentBoardId} />
-					</Resizable.Pane>
-				{/if}
-			</Resizable.PaneGroup>
-		</div>
-	{/if}
-</div>
 
 <!-- ImportPopover Component (hidden, used for share-link preview) -->
 <ImportPopover bind:this={importPopoverComponent} />
 
-<!-- FollowBoardDialog Component (shown when user opens share link) -->
+<!-- FollowBoardDialog Component (shown when user opens share link via URL params) -->
 <FollowBoardDialog 
 	bind:open={showFollowDialog}
 	boardId={shareLinkBoardId}

--- a/src/routes/cardsboard/BoardsList.svelte
+++ b/src/routes/cardsboard/BoardsList.svelte
@@ -7,10 +7,12 @@
     import * as RadioGroup from '$lib/components/ui/radio-group/index.js';
     import * as Popover from '$lib/components/ui/popover/index.js';
     import { slide } from 'svelte/transition';
+    import { goto } from '$app/navigation';
     import { boardStore } from '$lib/stores/kanbanStore.svelte.js';
     import { authStore } from '$lib/index.js';
     import { BoardRole } from '$lib/types/sharing';
     import { toast } from 'svelte-sonner';
+    import { createBoardNaddrUrl } from '$lib/utils/nostrEvents.js';
 
     import MenuItem from './MenuItem.svelte';
     import SubmenuItem from './SubmenuItem.svelte';
@@ -192,6 +194,27 @@
         return uniqueBoards;
     });
 
+    /**
+     * Navigiere zur naddr-URL des aktuellen Boards.
+     * Nutzt replaceState damit kein neuer History-Eintrag pro Board-Wechsel entsteht.
+     */
+    function navigateToBoardUrl() {
+        const board = boardStore.data;
+        if (board?.author) {
+            try {
+                const naddrUrl = createBoardNaddrUrl(board.id, board.author);
+                goto(naddrUrl, { replaceState: true });
+            } catch (error) {
+                console.warn('⚠️ Konnte naddr-URL nicht erstellen:', error);
+                // Fallback: Bleibe auf /cardsboard/
+                goto('/cardsboard/', { replaceState: true });
+            }
+        } else {
+            // Kein Author (z.B. lokales Board ohne Nostr-Pubkey) → einfache URL
+            goto('/cardsboard/', { replaceState: true });
+        }
+    }
+
     // Event: Neues Board erstellen
     async function handleCreateBoard() {
         isCreating = true;
@@ -199,6 +222,7 @@
             const newBoardId = boardStore.createBoard('Neues Board');
             boardStore.loadBoard(newBoardId);
             currentBoardId = newBoardId;
+            navigateToBoardUrl();
 
             searchQuery = '';
         } catch (error) {
@@ -220,6 +244,7 @@
             const success = boardStore.loadBoard(boardId);
             if (success) {
                 currentBoardId = boardId;
+                navigateToBoardUrl();
                 console.log('✅ Board geladen:', boardId);
             }
         } catch (error) {
@@ -546,8 +571,10 @@
                             const newBoardId = remaining[0].id;
                             boardStore.loadBoard(newBoardId);
                             currentBoardId = newBoardId;
+                            navigateToBoardUrl();
                         } else {
                             currentBoardId = '';
+                            goto('/cardsboard/', { replaceState: true });
                         }
                     } catch (error) {
                         console.error('❌ Fehler beim Löschen/Verlassen:', error);
@@ -849,6 +876,7 @@
                             importFile = null;
                             if (result.board?.id) {
                                 boardStore.loadBoard(result.board.id);
+                                navigateToBoardUrl();
                             }
                         } else {
                             toast.error(`Import fehlgeschlagen: ${result.error}`);

--- a/src/routes/cardsboard/BoardsList.svelte
+++ b/src/routes/cardsboard/BoardsList.svelte
@@ -183,6 +183,41 @@
         for (const board of sharedBoards) {
             boardMap.set(board.id, board);
         }
+
+        // ✅ Aktives Fremd-Board einfügen wenn es nicht in boardMap ist (z.B. nach Seiten-Reload).
+        // Nach einem Reload ist cachedSharedBoards leer (onAuthChanged clears it) und die Nostr-
+        // Abfrage noch nicht abgeschlossen. Das Board ist aber in localStorage vorhanden und wird
+        // vom Store geladen – es fehlt nur in der Sidebar-Liste.
+        const activeBoardId = boardStore.data?.id;
+        const activeBoard = boardStore.data;
+        if (
+            activeBoardId &&
+            activeBoardId === currentBoardId &&
+            !boardMap.has(activeBoardId) &&
+            activeBoard?.author &&
+            activeBoard.author !== authStore.getPubkey()
+        ) {
+            const lastAccTimestamp = activeBoard.lastAccessedAt
+                ? new Date(activeBoard.lastAccessedAt).getTime()
+                : undefined;
+            const updatedTimestamp = activeBoard.updatedAt
+                ? new Date(activeBoard.updatedAt).getTime()
+                : undefined;
+            const createdTimestamp = activeBoard.createdAt
+                ? new Date(activeBoard.createdAt).getTime()
+                : Date.now();
+            boardMap.set(activeBoardId, {
+                id: activeBoardId,
+                name: activeBoard.name,
+                description: activeBoard.description,
+                createdAt: createdTimestamp,
+                updatedAt: updatedTimestamp,
+                lastAccessed: lastAccTimestamp,
+                isShared: true,
+                userRole: 'viewer',
+                author: activeBoard.author
+            });
+        }
         
         // Konvertiere zu Array und sortiere nach lastAccessed (neueste zuerst)
         const uniqueBoards = Array.from(boardMap.values()).sort((a, b) => {

--- a/src/routes/cardsboard/Topbar.svelte
+++ b/src/routes/cardsboard/Topbar.svelte
@@ -43,6 +43,7 @@
     let isBoardPublished = $derived(boardStore.data?.publishState === 'published');
     let userRole = $derived(boardStore.getCurrentUserRole());
     let isOwner = $derived(userRole === BoardRole.OWNER);
+    let canEdit = $derived(boardStore.canCurrentUserEdit());
     let editorRequestCount = $derived(Object.keys(editorRequestsByPubkey).length);
 
     const greenStyling = 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300 border-green-300 dark:border-green-700'
@@ -241,7 +242,7 @@
                         class="font-semibold text-lg bg-transparent border-b-2 border-primary outline-none px-1 min-w-[150px] max-w-[400px]"
                         style="width: {Math.max(150, editTitleValue.length * 10)}px"
                     />
-                {:else}
+                {:else if canEdit}
                     <button
                         onclick={startEditingTitle}
                         class="font-semibold text-lg hover:bg-muted px-1 rounded cursor-text transition-colors group flex items-center gap-1"
@@ -250,6 +251,8 @@
                         {currentBoardTitle}
                         <PencilIcon class="h-3 w-3 opacity-0 group-hover:opacity-50 transition-opacity" />
                     </button>
+                {:else}
+                    <span class="font-semibold text-lg px-1">{currentBoardTitle}</span>
                 {/if}
                 
                 <!-- CC License Badge (superscript style) -->
@@ -305,7 +308,8 @@
                 <Separator orientation="vertical" class="min-w-0.5 sm:min-w-3" />
             {/if}
             
-            <!-- Right Sidebar Trigger -->
+            <!-- Right Sidebar Trigger - nur für Nutzer mit Bearbeitungsrecht -->
+            {#if canEdit}
             <Button
                 variant="ghost"
                 size="icon"
@@ -315,6 +319,7 @@
                 <BotIcon class="h-4 w-4"/>
                 <span class="sr-only">Toggle Right Sidebar</span>
             </Button>
+            {/if}
         </div>
     </div>
 </header>

--- a/src/routes/cardsboard/Topbar.svelte
+++ b/src/routes/cardsboard/Topbar.svelte
@@ -7,9 +7,10 @@
     import BellIcon from "@lucide/svelte/icons/bell";
     import BookmarkPlusIcon from "@lucide/svelte/icons/bookmark-plus";
     import { boardStore } from '$lib/stores/kanbanStore.svelte.js';
-    import { followBoardState } from '$lib/stores/followBoardState.svelte.js';
+    import { authStore } from '$lib/stores/authStore.svelte.js';
     import { BotIcon } from 'lucide-svelte';
     import PublishToEdufeedDialog from './PublishToEdufeedDialog.svelte';
+    import FollowBoardDialog from '$lib/components/board/FollowBoardDialog.svelte';
     import { onMount } from 'svelte';
     import { settingsStore } from '$lib/stores/settingsStore.svelte';
     import { toast } from 'svelte-sonner';
@@ -19,6 +20,9 @@
     
     // State für Edufeed-Dialog
     let showEdufeedDialog = $state(false);
+
+    // State für Follow/Fork-Dialog (Fremdboad beobachten oder kopieren)
+    let showFollowDialog = $state(false);
     let showEditorRequestsDialog = $state(false);
     let editorRequestsByPubkey = $state<Record<string, { eventId: string; createdAt?: number; reason?: string; role?: string }>>({});
     let editorRequestsLoadToken = $state(0);
@@ -47,6 +51,16 @@
     let isOwner = $derived(userRole === BoardRole.OWNER);
     let canEdit = $derived(boardStore.canCurrentUserEdit());
     let editorRequestCount = $derived(Object.keys(editorRequestsByPubkey).length);
+
+    // ✅ Zeige "Speichern"-CTA wenn: eingeloggt + Board gehört jemand anderem + noch nicht offiziell gefolgt
+    // Diese Ableitung funktioniert auch nach einem Seiten-Reload zuverlässig,
+    // weil sie nur reaktive Stores nutzt (kein runtime-only followBoardState).
+    let showFollowCTA = $derived(
+        authStore.isAuthenticated &&
+        !!boardStore.data?.author &&
+        boardStore.data.author !== authStore.getPubkey() &&
+        !boardStore.isCurrentBoardFollowedByUser()
+    );
 
     const greenStyling = 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300 border-green-300 dark:border-green-700'
     const yellowStyling = 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300 border-yellow-300 dark:border-yellow-700'
@@ -323,14 +337,14 @@
             </Button>
             {/if}
 
-            <!-- Follow-CTA: sichtbar wenn Fremdbord über naddr geladen wurde -->
-            {#if followBoardState.hasPending}
+            <!-- Follow-CTA: sichtbar wenn Fremdbord eingeloggt angeschaut wird (auch nach Reload!) -->
+            {#if showFollowCTA}
                 <Separator orientation="vertical" class="min-w-0.5 sm:min-w-3" />
                 <Button
                     variant="outline"
                     size="sm"
                     class="h-8 border-amber-400 text-amber-600 hover:bg-amber-50 dark:border-amber-600 dark:text-amber-400 dark:hover:bg-amber-950 gap-1.5"
-                    onclick={() => followBoardState.requestOpen()}
+                    onclick={() => { showFollowDialog = true; }}
                     title="Board beobachten oder als eigene Kopie importieren"
                 >
                     <BookmarkPlusIcon class="h-4 w-4" />
@@ -343,6 +357,15 @@
 
 <!-- Edufeed Publish Dialog -->
 <PublishToEdufeedDialog bind:open={showEdufeedDialog} />
+
+<!-- Follow/Fork-Dialog für Fremd-Boards -->
+{#if showFollowCTA || showFollowDialog}
+    <FollowBoardDialog
+        bind:open={showFollowDialog}
+        boardId={boardStore.data?.id ?? ''}
+        boardAuthor={boardStore.data?.author ?? ''}
+    />
+{/if}
 
 <!-- Owner: Editor-Requests Dialog (öffnet ShareDialog im Editor-Tab) -->
 {#if isOwner}

--- a/src/routes/cardsboard/Topbar.svelte
+++ b/src/routes/cardsboard/Topbar.svelte
@@ -5,7 +5,9 @@
     import MenuIcon from "@lucide/svelte/icons/menu";
     import ShareIcon from "@lucide/svelte/icons/share-2";
     import BellIcon from "@lucide/svelte/icons/bell";
+    import BookmarkPlusIcon from "@lucide/svelte/icons/bookmark-plus";
     import { boardStore } from '$lib/stores/kanbanStore.svelte.js';
+    import { followBoardState } from '$lib/stores/followBoardState.svelte.js';
     import { BotIcon } from 'lucide-svelte';
     import PublishToEdufeedDialog from './PublishToEdufeedDialog.svelte';
     import { onMount } from 'svelte';
@@ -319,6 +321,21 @@
                 <BotIcon class="h-4 w-4"/>
                 <span class="sr-only">Toggle Right Sidebar</span>
             </Button>
+            {/if}
+
+            <!-- Follow-CTA: sichtbar wenn Fremdbord über naddr geladen wurde -->
+            {#if followBoardState.hasPending}
+                <Separator orientation="vertical" class="min-w-0.5 sm:min-w-3" />
+                <Button
+                    variant="outline"
+                    size="sm"
+                    class="h-8 border-amber-400 text-amber-600 hover:bg-amber-50 dark:border-amber-600 dark:text-amber-400 dark:hover:bg-amber-950 gap-1.5"
+                    onclick={() => followBoardState.requestOpen()}
+                    title="Board beobachten oder als eigene Kopie importieren"
+                >
+                    <BookmarkPlusIcon class="h-4 w-4" />
+                    <span class="hidden sm:inline text-xs">Speichern</span>
+                </Button>
             {/if}
         </div>
     </div>

--- a/src/routes/cardsboard/[naddr]/+page.svelte
+++ b/src/routes/cardsboard/[naddr]/+page.svelte
@@ -1,18 +1,18 @@
 <script lang="ts">
     /**
-     * naddr Route: Lade Board aus Nostr und weiterleiten zur normalen Ansicht
+     * naddr Route: Lade Board aus Nostr und zeige es inline
      * 
-     * Diese Route dient nur als Lademechanismus:
+     * Die URL bleibt als permanenter Share-Link erhalten:
      * 1. Dekodiere naddr aus URL
      * 2. Verbinde mit Relay-Hints
      * 3. Lade Board + Cards von Nostr
      * 4. Speichere in BoardStore (localStorage)
-     * 5. Weiterleitung zu /cardsboard/ (normale Ansicht)
+     * 5. Board wird über das gemeinsame +layout.svelte angezeigt (kein Redirect)
      * 
      * Dadurch funktioniert alles normal: Sidebar, Topbar, Bearbeitung (wenn Owner)
+     * Die naddr-URL kann direkt als Share-Link weitergegeben werden.
      */
     import { page } from '$app/stores';
-    import { goto } from '$app/navigation';
     import { base } from '$app/paths';
     import { onMount } from 'svelte';
     import { boardStore } from '$lib/stores/kanbanStore.svelte.js';
@@ -308,7 +308,6 @@
                                     boardStore.refreshBoardIds();
                                     boardStore.loadBoard(snapshotJson.id);
                                     status = 'success';
-                                    await goto(`${base}/cardsboard/`, { replaceState: true });
                                     return;
                                 } catch (err) {
                                     console.warn('Fehler beim Parsen des Snapshot-Inhalts:', err);
@@ -333,9 +332,7 @@
                 // Lade das Board im Store
                 boardStore.loadBoard(boardId);
                 
-                // Weiterleitung
                 status = 'success';
-                await goto(`${base}/cardsboard/`, { replaceState: true });
                 return;
             }
 
@@ -385,11 +382,9 @@
             loadingStep = 'Board wird geöffnet...';
             boardStore.loadBoard(board.id);
 
-            // 9. Weiterleitung zur normalen Ansicht
+            // 9. Board ist geladen — Layout rendert es automatisch
             status = 'success';
-            console.log('✅ Board geladen und gespeichert, leite weiter...');
-            
-            await goto(`${base}/cardsboard/`, { replaceState: true });
+            console.log('✅ Board geladen und gespeichert, URL bleibt als Share-Link');
 
         } catch (error) {
             console.error('❌ Fehler beim Laden:', error);
@@ -403,15 +398,20 @@
     });
 </script>
 
-<div class="min-h-screen bg-background flex items-center justify-center">
-    <div class="text-center p-8 max-w-md">
-        {#if status === 'loading'}
+<!-- Loading/Error Overlay (position: fixed, überlagert das Board aus dem Layout) -->
+{#if status === 'loading'}
+    <div class="fixed inset-0 z-50 bg-background flex items-center justify-center">
+        <div class="text-center p-8 max-w-md">
             <div class="flex flex-col items-center gap-4">
                 <LoaderCircleIcon class="h-12 w-12 animate-spin text-primary" />
                 <h1 class="text-xl font-semibold">Board wird geladen...</h1>
                 <p class="text-muted-foreground">{loadingStep}</p>
             </div>
-        {:else if status === 'error'}
+        </div>
+    </div>
+{:else if status === 'error'}
+    <div class="fixed inset-0 z-50 bg-background flex items-center justify-center">
+        <div class="text-center p-8 max-w-md">
             <div class="flex flex-col items-center gap-4">
                 <AlertCircleIcon class="h-12 w-12 text-destructive" />
                 <h1 class="text-xl font-semibold text-destructive">Fehler beim Laden</h1>
@@ -423,26 +423,8 @@
                     Zurück zur Übersicht
                 </a>
             </div>
-        {:else if status === 'success'}
-            <div class="flex flex-col items-center gap-4">
-                <h1 class="text-xl font-semibold">Board-Link geöffnet</h1>
-                <p class="text-muted-foreground">Bitte wähle „Beobachten“ oder „Fork“ im Dialog.</p>
-                <button
-                    type="button"
-                    class="mt-2 text-primary hover:underline"
-                    onclick={() => (showFollowDialog = true)}
-                >
-                    Dialog erneut öffnen
-                </button>
-                <a
-                    href="{base}/cardsboard/"
-                    class="text-muted-foreground hover:underline"
-                >
-                    Zurück zur Übersicht
-                </a>
-            </div>
-        {/if}
+        </div>
     </div>
-</div>
+{/if}
 
 <FollowBoardDialog bind:open={showFollowDialog} boardId={followBoardId} boardAuthor={followBoardAuthor} />

--- a/src/routes/cardsboard/[naddr]/+page.svelte
+++ b/src/routes/cardsboard/[naddr]/+page.svelte
@@ -24,21 +24,11 @@
     import { NDKEvent, NDKRelay, nip19 } from '@nostr-dev-kit/ndk';
     import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
     import AlertCircleIcon from '@lucide/svelte/icons/alert-circle';
-    import FollowBoardDialog from '$lib/components/board/FollowBoardDialog.svelte';
 
     // State
     let status = $state<'loading' | 'error' | 'success'>('loading');
     let errorMessage = $state('');
     let loadingStep = $state('naddr dekodieren...');
-    let showFollowDialog = $state(false);
-
-    // Wenn Topbar-Button geklickt wird → Dialog öffnen
-    $effect(() => {
-        if (followBoardState.shouldOpen) {
-            showFollowDialog = true;
-            followBoardState.shouldOpen = false;
-        }
-    });
 
     onDestroy(() => followBoardState.clear());
 
@@ -465,8 +455,4 @@
     </div>
 {/if}
 
-<FollowBoardDialog
-    bind:open={showFollowDialog}
-    boardId={followBoardState.boardId ?? ''}
-    boardAuthor={followBoardState.boardAuthor ?? ''}
-/>
+

--- a/src/routes/cardsboard/[naddr]/+page.svelte
+++ b/src/routes/cardsboard/[naddr]/+page.svelte
@@ -220,26 +220,7 @@
      */
     async function loadAndRedirect() {
         try {
-            // 1. Warte auf NDK
-            loadingStep = 'NDK initialisieren...';
-            
-            // Warte bis boardStore.ndkReady true ist
-            let attempts = 0;
-            while (!boardStore.ndkReady && attempts < 50) {
-                await new Promise(resolve => setTimeout(resolve, 100));
-                attempts++;
-            }
-            
-            if (!boardStore.ndkReady) {
-                throw new Error('NDK konnte nicht initialisiert werden');
-            }
-
-            const ndk = boardStore.nostrIntegration?.getNDK();
-            if (!ndk) {
-                throw new Error('NDK nicht verfügbar');
-            }
-
-            // 2. Dekodiere naddr
+            // 1. Dekodiere naddr (reine Funktion, braucht kein NDK)
             loadingStep = 'naddr dekodieren...';
             const naddrParam = $page.params.naddr;
             
@@ -264,6 +245,8 @@
                 relays: naddrData.relays
             });
 
+            // 2. Quick-Checks BEVOR NDK gewartet wird (brauchen kein Netzwerk)
+            
             // ✅ Quick-Check: Board ist bereits das aktive Board → sofort fertig
             if (boardStore.data?.id === naddrData.identifier) {
                 console.log('✅ Board ist bereits aktiv, überspringe Laden');
@@ -283,7 +266,59 @@
                 return;
             }
 
-            // 3. Verbinde zu Relay-Hints
+            // ✅ Check: Board bereits lokal im Cache → direkt laden (kein NDK nötig)
+            const boardId = naddrData.identifier;
+            const existingBoard = BoardStorage.loadBoard(boardId);
+            
+            if (existingBoard) {
+                console.log('✅ Board bereits lokal vorhanden, lade direkt');
+                loadingStep = 'Board wird geöffnet...';
+                boardStore.loadBoard(boardId);
+
+                // Viewer-CTA: eingeloggt aber nicht Owner → Follow-Button in Topbar anzeigen
+                const cachedUserPubkey = authStore.getPubkey();
+                if (cachedUserPubkey && naddrData.pubkey && naddrData.pubkey !== cachedUserPubkey) {
+                    const updatedAtMs = existingBoard.updatedAt
+                        ? new Date(existingBoard.updatedAt).getTime()
+                        : undefined;
+                    boardStore.handleSharedBoardEvent({
+                        id: boardId,
+                        name: existingBoard.name,
+                        description: existingBoard.description,
+                        createdAt: new Date(existingBoard.createdAt).getTime(),
+                        updatedAt: updatedAtMs,
+                        isShared: true,
+                        userRole: 'viewer',
+                        author: naddrData.pubkey
+                    });
+                    boardStore.refreshBoardIds();
+                    followBoardState.setPending(boardId, naddrData.pubkey);
+                }
+
+                status = 'success';
+                return;
+            }
+
+            // 3. Ab hier: Board muss von Nostr geladen werden → NDK erforderlich
+            loadingStep = 'NDK initialisieren...';
+            
+            // Warte bis boardStore.ndkReady true ist
+            let attempts = 0;
+            while (!boardStore.ndkReady && attempts < 50) {
+                await new Promise(resolve => setTimeout(resolve, 100));
+                attempts++;
+            }
+            
+            if (!boardStore.ndkReady) {
+                throw new Error('NDK konnte nicht initialisiert werden');
+            }
+
+            const ndk = boardStore.nostrIntegration?.getNDK();
+            if (!ndk) {
+                throw new Error('NDK nicht verfügbar');
+            }
+
+            // 4. Verbinde zu Relay-Hints
             loadingStep = 'Verbinde zu Relays...';
             await connectToRelayHints(ndk, naddrData.relays);
 
@@ -327,39 +362,6 @@
                 } catch (err) {
                     console.warn('Error while searching AMB for a-tag', aCandidate, err);
                 }
-            }
-
-            // 4. Prüfe ob Board bereits lokal existiert
-            const boardId = naddrData.identifier;
-            const existingBoard = BoardStorage.loadBoard(boardId);
-            
-            if (existingBoard) {
-                console.log('✅ Board bereits lokal vorhanden, lade direkt');
-                loadingStep = 'Board wird geöffnet...';
-                boardStore.loadBoard(boardId);
-
-                // Viewer-CTA: eingeloggt aber nicht Owner → Follow-Button in Topbar anzeigen
-                const cachedUserPubkey = authStore.getPubkey();
-                if (cachedUserPubkey && naddrData.pubkey && naddrData.pubkey !== cachedUserPubkey) {
-                    const updatedAtMs = existingBoard.updatedAt
-                        ? new Date(existingBoard.updatedAt).getTime()
-                        : undefined;
-                    boardStore.handleSharedBoardEvent({
-                        id: boardId,
-                        name: existingBoard.name,
-                        description: existingBoard.description,
-                        createdAt: new Date(existingBoard.createdAt).getTime(),
-                        updatedAt: updatedAtMs,
-                        isShared: true,
-                        userRole: 'viewer',
-                        author: naddrData.pubkey
-                    });
-                    boardStore.refreshBoardIds();
-                    followBoardState.setPending(boardId, naddrData.pubkey);
-                }
-
-                status = 'success';
-                return;
             }
 
             // 5. Lade Board von Nostr

--- a/src/routes/cardsboard/[naddr]/+page.svelte
+++ b/src/routes/cardsboard/[naddr]/+page.svelte
@@ -272,10 +272,12 @@
                 return;
             }
 
-            // ✅ Check: Board ist bereits lokal vorhanden → direkt laden
-            const existingLocalBoard = BoardStorage.loadBoard(naddrData.identifier);
-            if (existingLocalBoard) {
-                console.log('✅ Board bereits lokal vorhanden, lade direkt (kein Dialog)');
+            // ✅ Check: Board gehört dem aktuellen User (Owner/Maintainer) → direkt laden (kein Dialog)
+            // WICHTIG: BoardStorage.loadBoard() prüft NUR localStorage - auch fremde Boards können cached sein!
+            // getAllBoards() filtert korrekt auf User-eigene Boards → fremde Boards IMMER über FollowDialog
+            const isUsersOwnBoard = boardStore.getAllBoards().some(b => b.id === naddrData.identifier);
+            if (isUsersOwnBoard) {
+                console.log('✅ Board ist Nutzer-eigenes Board, lade direkt (kein Dialog)');
                 loadingStep = 'Board wird geöffnet...';
                 boardStore.loadBoard(naddrData.identifier);
                 status = 'success';

--- a/src/routes/cardsboard/[naddr]/+page.svelte
+++ b/src/routes/cardsboard/[naddr]/+page.svelte
@@ -265,11 +265,28 @@
                 relays: naddrData.relays
             });
 
+            // ✅ Quick-Check: Board ist bereits das aktive Board → sofort fertig
+            if (boardStore.data?.id === naddrData.identifier) {
+                console.log('✅ Board ist bereits aktiv, überspringe Laden');
+                status = 'success';
+                return;
+            }
+
+            // ✅ Check: Board ist bereits lokal vorhanden → direkt laden
+            const existingLocalBoard = BoardStorage.loadBoard(naddrData.identifier);
+            if (existingLocalBoard) {
+                console.log('✅ Board bereits lokal vorhanden, lade direkt (kein Dialog)');
+                loadingStep = 'Board wird geöffnet...';
+                boardStore.loadBoard(naddrData.identifier);
+                status = 'success';
+                return;
+            }
+
             // 3. Verbinde zu Relay-Hints
             loadingStep = 'Verbinde zu Relays...';
             await connectToRelayHints(ndk, naddrData.relays);
 
-            // ✅ Eingeloggt: Share-Link bleibt, Dialog steuert Follow/Fork
+            // ✅ Eingeloggt + Board NICHT lokal: Share-Link bleibt, Dialog steuert Follow/Fork
             const currentUserPubkey = authStore.getPubkey();
             if (currentUserPubkey) {
                 followBoardId = naddrData.identifier;

--- a/src/routes/cardsboard/[naddr]/+page.svelte
+++ b/src/routes/cardsboard/[naddr]/+page.svelte
@@ -14,9 +14,10 @@
      */
     import { page } from '$app/stores';
     import { base } from '$app/paths';
-    import { onMount } from 'svelte';
+    import { onMount, onDestroy } from 'svelte';
     import { boardStore } from '$lib/stores/kanbanStore.svelte.js';
     import { authStore } from '$lib/stores/authStore.svelte.js';
+    import { followBoardState } from '$lib/stores/followBoardState.svelte.js';
     import { Board, Card, Column, type CardProps } from '$lib/classes/BoardModel.js';
     import { BoardStorage } from '$lib/stores/boardstore/storage.js';
     import type NDK from '@nostr-dev-kit/ndk';
@@ -30,8 +31,16 @@
     let errorMessage = $state('');
     let loadingStep = $state('naddr dekodieren...');
     let showFollowDialog = $state(false);
-    let followBoardId = $state('');
-    let followBoardAuthor = $state('');
+
+    // Wenn Topbar-Button geklickt wird → Dialog öffnen
+    $effect(() => {
+        if (followBoardState.shouldOpen) {
+            showFollowDialog = true;
+            followBoardState.shouldOpen = false;
+        }
+    });
+
+    onDestroy(() => followBoardState.clear());
 
     interface NaddrData {
         kind: number;
@@ -288,16 +297,6 @@
             loadingStep = 'Verbinde zu Relays...';
             await connectToRelayHints(ndk, naddrData.relays);
 
-            // ✅ Eingeloggt + Board NICHT lokal: Share-Link bleibt, Dialog steuert Follow/Fork
-            const currentUserPubkey = authStore.getPubkey();
-            if (currentUserPubkey) {
-                followBoardId = naddrData.identifier;
-                followBoardAuthor = naddrData.pubkey;
-                showFollowDialog = true;
-                status = 'success';
-                return;
-            }
-
             // 3b. Versuche zuerst AMB (30142) zu finden, die ['a', <naddr>] oder ['a', address] enthält
             loadingStep = 'Suche AMB Snapshot...';
             const aTagCandidates: string[] = [];
@@ -347,10 +346,28 @@
             if (existingBoard) {
                 console.log('✅ Board bereits lokal vorhanden, lade direkt');
                 loadingStep = 'Board wird geöffnet...';
-                
-                // Lade das Board im Store
                 boardStore.loadBoard(boardId);
-                
+
+                // Viewer-CTA: eingeloggt aber nicht Owner → Follow-Button in Topbar anzeigen
+                const cachedUserPubkey = authStore.getPubkey();
+                if (cachedUserPubkey && naddrData.pubkey && naddrData.pubkey !== cachedUserPubkey) {
+                    const updatedAtMs = existingBoard.updatedAt
+                        ? new Date(existingBoard.updatedAt).getTime()
+                        : undefined;
+                    boardStore.handleSharedBoardEvent({
+                        id: boardId,
+                        name: existingBoard.name,
+                        description: existingBoard.description,
+                        createdAt: new Date(existingBoard.createdAt).getTime(),
+                        updatedAt: updatedAtMs,
+                        isShared: true,
+                        userRole: 'viewer',
+                        author: naddrData.pubkey
+                    });
+                    boardStore.refreshBoardIds();
+                    followBoardState.setPending(boardId, naddrData.pubkey);
+                }
+
                 status = 'success';
                 return;
             }
@@ -392,6 +409,8 @@
                     userRole: 'viewer',
                     author: board.author
                 });
+                // Follow-CTA in Topbar anzeigen statt Dialog sofort aufzwingen
+                followBoardState.setPending(board.id, board.author);
             }
             
             // Board-IDs neu laden damit es in der Liste erscheint
@@ -446,4 +465,8 @@
     </div>
 {/if}
 
-<FollowBoardDialog bind:open={showFollowDialog} boardId={followBoardId} boardAuthor={followBoardAuthor} />
+<FollowBoardDialog
+    bind:open={showFollowDialog}
+    boardId={followBoardState.boardId ?? ''}
+    boardAuthor={followBoardState.boardAuthor ?? ''}
+/>

--- a/static/config.json
+++ b/static/config.json
@@ -1,55 +1,47 @@
 {
   "$comment": "Kanban Board Configuration - Single Source of Truth",
   "$schema_version": "1.1.0",
-  "$last_updated": "2025-11-04",
+  "$last_updated": "2026-02-04",
 
   "ui": {
     "maxCardsBeforeScroll": 20,
     "alignColumnsToMaxHeight": true,
     "columnWidth": 350,
+    "theme": "system",
     "$comment": "UI-spezifische Einstellungen für Layout und Darstellung"
   },
 
   "nostr": {
     "relaysPublic": [
-      "wss://relay-rpi.edufeed.org",
       "wss://relay.edufeed.org",
-      "ws://localhost:7000"
+      "wss://relay-rpi.edufeed.org",
+      "wss://relay.primal.net",
+      "wss://nos.lol"
     ],
-    "relaysPrivate": [
-      "ws://localhost:7000"
-    ],
-    "relaysEdufeed": [
-      "wss://amb-relay.edufeed.org"
-    ],
-    "njumpUrl": "https://njump.edufeed.org",
-    "$comment": "⚠️ Development: Verwende 'ws://localhost:7000' nur wenn lokaler Docker-Relay läuft! Production: Nutze öffentliche wss:// Relays.",
-    "$comment_localhost": "Lokaler Relay für Tests: ws://localhost:7000 (erfordert: docker-compose up -d)",
-    "$comment_njump": "njumpUrl: Web-Client für Nostr-Links (naddr, nevent, note URLs)",
-    "$comment_edufeed": "relaysEdufeed: Relays für AMB (Kind 30142) Publishing - nur amb-relay.edufeed.org akzeptiert diese Events!"
+    "relaysPrivate": ["wss://kanban.edufeed.org/nostr/"]
   },
 
   "llm": {
-    "model": "glm-4.7-flash",
-    "baseUrl": "http://localhost:11434",
+    "model": "sonate-4.7",
+    "baseUrl": "https://kanban.edufeed.org/llm/api",
     "apiKey": "",
     "$comment_apiKey": "⚠️ SECURITY: Nur für lokales Ollama speichern! Remote APIs: .env.local nutzen!",
     "systemPrompt": "Du bist ein hilfreicher KI-Assistant für Kanban Board Management. Helfe dem Benutzer beim Organisieren und Strukturieren von Aufgaben."
   },
 
   "oidc": {
-    "authority": "http://localhost:8080/realms/master",
+    "authority": "https://login.rpi-virtuell.de/realms/rpi/",
     "clientId": "kanban-board"
   },
 
   "mcp": {
     "urls": []
   },
-  "shareTokenMaxSize": 200000,
 
   "defaults": {
     "columns": ["Material", "Einstieg","Erarbeitung", "Sicherung"],
-    "boardPublishState": "private"
+    "boardPublishState": "draft",
+    "cardPublishState": "draft"
   },
 
   "sidebar": {
@@ -58,35 +50,28 @@
   },
 
   "oerFinderPlugin": {
-    "apiUrl": "http://localhost:3001",
+    "apiUrl": "https://kanban.edufeed.org/oer-finder",
     "language": "de"
   },
   
   "allow_demo_session": {
     "enabled": false
   },
-
   "wissenswertes": {
     "sourceCodeUrl": "https://github.com/edufeed-org/kanban-editor",
     "documentationUrl": "https://github.com/edufeed-org/kanban-editor/tree/cardsboard/docs/MANUAL#readme",
     "aboutUrl": "https://github.com/edufeed-org/kanban-editor#readme",
     "$comment": "Konfigurierbare Links für das Wissenswertes-Menü"
   },
-
   "amb": {
-    "$comment": "AMB (Allgemeines Metadatenprofil für Bildungsressourcen) Konfiguration",
-    "$comment_vocabularies": "URLs können angepasst werden für verschiedene Kontexte (Schule, Hochschule, Beruf). Setze auf null für Default-URL.",
-    "vocabularies": {
-      "audience": null,
-      "educationalLevel": null,
-      "learningResourceType": null,
-      "about": null
+    "$comment": "AMB (Allgemeines Metadatenprofil für Bildungsressourcen) - Vokabular-URLs für dynamisches Laden",
+    "vocabularyUrls": {
+      "audience": "https://skohub.io/dini-ag-kim/lrmi-audience-role/heads/master/w3id.org/kim/lrmi-audience-role/index.json",
+      "educationalLevel": "https://skohub.io/dini-ag-kim/educationalLevel/heads/main/w3id.org/kim/educationalLevel/index.json",
+      "learningResourceType": "https://skohub.io/dini-ag-kim/hcrt/heads/master/w3id.org/kim/hcrt/index.json",
+      "about": "https://skohub.io/dini-ag-kim/schulfaecher/heads/main/w3id.org/kim/schulfaecher/index.json"
     },
-    "$comment_example_hochschule": {
-      "about": "https://skohub.io/dini-ag-kim/hochschulfaechersystematik/heads/main/w3id.org/kim/hochschulfaechersystematik/index.json",
-      "$note": "Beispiel für Hochschulkontext: Hochschulfächersystematik statt Schulfächer"
-    },
-    "cacheTTL": 86400000,
-    "$comment_cacheTTL": "Cache-Dauer in Millisekunden (86400000 = 24 Stunden)"
+    "cacheTtlHours": 24,
+    "$comment_vocabularies": "audience=Zielgruppen, educationalLevel=Bildungsstufen, learningResourceType=Ressourcentypen (HCRT), about=Fächer/Themen (Schulfächer)"
   }
 }

--- a/static/config_.json
+++ b/static/config_.json
@@ -1,0 +1,92 @@
+{
+  "$comment": "Kanban Board Configuration - Single Source of Truth",
+  "$schema_version": "1.1.0",
+  "$last_updated": "2025-11-04",
+
+  "ui": {
+    "maxCardsBeforeScroll": 20,
+    "alignColumnsToMaxHeight": true,
+    "columnWidth": 350,
+    "$comment": "UI-spezifische Einstellungen für Layout und Darstellung"
+  },
+
+  "nostr": {
+    "relaysPublic": [
+      "wss://relay-rpi.edufeed.org",
+      "wss://relay.edufeed.org",
+      "ws://localhost:7000"
+    ],
+    "relaysPrivate": [
+      "ws://localhost:7000"
+    ],
+    "relaysEdufeed": [
+      "wss://amb-relay.edufeed.org"
+    ],
+    "njumpUrl": "https://njump.edufeed.org",
+    "$comment": "⚠️ Development: Verwende 'ws://localhost:7000' nur wenn lokaler Docker-Relay läuft! Production: Nutze öffentliche wss:// Relays.",
+    "$comment_localhost": "Lokaler Relay für Tests: ws://localhost:7000 (erfordert: docker-compose up -d)",
+    "$comment_njump": "njumpUrl: Web-Client für Nostr-Links (naddr, nevent, note URLs)",
+    "$comment_edufeed": "relaysEdufeed: Relays für AMB (Kind 30142) Publishing - nur amb-relay.edufeed.org akzeptiert diese Events!"
+  },
+
+  "llm": {
+    "model": "glm-4.7-flash",
+    "baseUrl": "http://localhost:11434",
+    "apiKey": "",
+    "$comment_apiKey": "⚠️ SECURITY: Nur für lokales Ollama speichern! Remote APIs: .env.local nutzen!",
+    "systemPrompt": "Du bist ein hilfreicher KI-Assistant für Kanban Board Management. Helfe dem Benutzer beim Organisieren und Strukturieren von Aufgaben."
+  },
+
+  "oidc": {
+    "authority": "http://localhost:8080/realms/master",
+    "clientId": "kanban-board"
+  },
+
+  "mcp": {
+    "urls": []
+  },
+  "shareTokenMaxSize": 200000,
+
+  "defaults": {
+    "columns": ["Material", "Einstieg","Erarbeitung", "Sicherung"],
+    "boardPublishState": "private"
+  },
+
+  "sidebar": {
+    "showLeft": true,
+    "showRight": true
+  },
+
+  "oerFinderPlugin": {
+    "apiUrl": "http://localhost:3001",
+    "language": "de"
+  },
+  
+  "allow_demo_session": {
+    "enabled": false
+  },
+
+  "wissenswertes": {
+    "sourceCodeUrl": "https://github.com/edufeed-org/kanban-editor",
+    "documentationUrl": "https://github.com/edufeed-org/kanban-editor/tree/cardsboard/docs/MANUAL#readme",
+    "aboutUrl": "https://github.com/edufeed-org/kanban-editor#readme",
+    "$comment": "Konfigurierbare Links für das Wissenswertes-Menü"
+  },
+
+  "amb": {
+    "$comment": "AMB (Allgemeines Metadatenprofil für Bildungsressourcen) Konfiguration",
+    "$comment_vocabularies": "URLs können angepasst werden für verschiedene Kontexte (Schule, Hochschule, Beruf). Setze auf null für Default-URL.",
+    "vocabularies": {
+      "audience": null,
+      "educationalLevel": null,
+      "learningResourceType": null,
+      "about": null
+    },
+    "$comment_example_hochschule": {
+      "about": "https://skohub.io/dini-ag-kim/hochschulfaechersystematik/heads/main/w3id.org/kim/hochschulfaechersystematik/index.json",
+      "$note": "Beispiel für Hochschulkontext: Hochschulfächersystematik statt Schulfächer"
+    },
+    "cacheTTL": 86400000,
+    "$comment_cacheTTL": "Cache-Dauer in Millisekunden (86400000 = 24 Stunden)"
+  }
+}


### PR DESCRIPTION
 ## Fix Reload-Stabilität für Fremd-Boards & Demo-Board

### Beschreibung

Behebt drei zusammenhängende Probleme beim Betrachten fremder Boards über naddr-URLs nach einem Seiten-Reload sowie die fehlende Bearbeitbarkeit des Demo-Boards für anonyme Benutzer.

<img width="1250" height="387" alt="grafik" src="https://github.com/user-attachments/assets/4c4ef01e-3278-45fc-b968-72eb400ce3aa" />


### Probleme

1. **Speichern-Button verschwindet nach Reload** — Der amber „Speichern"-CTA in der Topbar basierte auf `followBoardState.hasPending`, einem runtime-only `$state` der bei jedem Seitenlade auf `null` zurückgesetzt wird.
2. **Fremd-Board fehlt in der BoardList nach Reload** — `cachedSharedBoards` wird von `onAuthChanged()` geleert; das Board ist nicht in der NIP-51-Follow-Liste des Viewers → erscheint nicht mehr in der Sidebar.
3. **Demo-Board nicht bearbeitbar für anonyme User** — `canCurrentUserEdit()` gab `false` zurück, obwohl `PermissionChecks` bereits eine Demo-Board-Ausnahme hatte. Das Layout setzte dadurch `readOnly={true}`.

### Lösung

**Topbar.svelte:**
- `followBoardState.hasPending` durch eine `$derived`-Ableitung ersetzt, die ausschließlich reaktive Stores nutzt:
  ```ts
  let showFollowCTA = $derived(
      authStore.isAuthenticated &&
      !!boardStore.data?.author &&
      boardStore.data.author !== authStore.getPubkey() &&
      !boardStore.isCurrentBoardFollowedByUser()
  );
  ```
- `FollowBoardDialog` von der naddr-Seite hierher verlagert — liest `boardStore.data` direkt statt über den `followBoardState`-Umweg.

**BoardsList.svelte:**
- In `filteredBoards` das aktuell aktive Board als temporären „Viewing"-Eintrag injiziert, wenn es weder in eigenen noch in shared Boards vorhanden ist und einem anderen Author gehört.

**[naddr]/+page.svelte:**
- `FollowBoardDialog` Import, State und Template entfernt (Verantwortung liegt jetzt bei Topbar).
- `$effect` für `followBoardState.shouldOpen` entfernt.

**kanbanStore.svelte.ts:**
- Demo-Board-Ausnahme in `canCurrentUserEdit()` ergänzt (konsistent mit `PermissionChecks`):
  ```ts
  if (this.board.id === 'demo-board') return true;
  ```

### Geänderte Dateien

| Datei | Änderung |
|-------|----------|
| Topbar.svelte | `showFollowCTA` derived, `FollowBoardDialog` übernommen |
| BoardsList.svelte | Aktives Fremd-Board in `filteredBoards` injiziert |
| +page.svelte | Dialog-Logik entfernt (Cleanup) |
| kanbanStore.svelte.ts | Demo-Board-Ausnahme in `canCurrentUserEdit()` |

### Testhinweise

- Fremdes Board über naddr-URL öffnen → Speichern-Button sichtbar ✓
- Seite reloaden → Button weiterhin sichtbar, Board in Sidebar-Liste ✓
- Als anonymer User `/cardsboard` öffnen → Demo-Board voll bearbeitbar ✓
- Eigenes Board öffnen → kein Speichern-Button ✓
- Board forken/folgen → Speichern-Button verschwindet ✓