### PR TITLE
feat: switch to local search for oer-finder-plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,3 +66,11 @@ ENTRYPOINT ["dumb-init", "--"]
 
 # Serve static files with sirv
 CMD ["pnpm", "exec", "sirv", "build", "--single", "--host", "0.0.0.0", "--port", "5173"]
+
+
+FROM node:22-alpine as development
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+WORKDIR /home/node/app
+
+COPY package.json pnpm-lock.yaml ./

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,18 @@
 services:
   # If the app needs to be started via docker compose, uncomment these lines of code and add a Dockerfile 
-  # app:
-  #   tty: true
-  #   stdin_open: true
-  #   build:
-  #     context: .
-  #     dockerfile: Dockerfile
-  #     target: development
-  #   volumes:
-  #     - .:/home/node/app
-  #   ports:
-  #     - "5173:5173"
+  app:
+    tty: true
+    stdin_open: true
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: development
+    volumes:
+      - .:/home/node/app
+    ports:
+      - "5173:5173"
+    environment:
+      - NODE_AUTH_TOKEN=${NODE_AUTH_TOKEN}
   nostr-relay:
     image: scsibug/nostr-rs-relay:latest
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,18 @@
 services:
   # If the app needs to be started via docker compose, uncomment these lines of code and add a Dockerfile 
-  app:
-    tty: true
-    stdin_open: true
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: development
-    volumes:
-      - .:/home/node/app
-    ports:
-      - "5173:5173"
-    environment:
-      - NODE_AUTH_TOKEN=${NODE_AUTH_TOKEN}
+  # app:
+  #   tty: true
+  #   stdin_open: true
+  #   build:
+  #     context: .
+  #     dockerfile: Dockerfile
+  #     target: development
+  #   volumes:
+  #     - .:/home/node/app
+  #   ports:
+  #     - "5173:5173"
+  #   environment:
+  #     - NODE_AUTH_TOKEN=${NODE_AUTH_TOKEN}
   nostr-relay:
     image: scsibug/nostr-rs-relay:latest
     ports:

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "overrides": {
       "nostr-tools": "~2.14.2",
       "@nostr-dev-kit/ndk": "^2.14.2",
-      "@edufeed-org/oer-finder-api-client": "^0.0.6"
+      "@edufeed-org/oer-finder-api-client": "^0.0.7"
     },
     "ignoredBuiltDependencies": [
       "svelte-preprocess"
@@ -102,7 +102,7 @@
   },
   "dependencies": {
     "@edufeed-org/amb-nostr-converter": "^0.0.1",
-    "@edufeed-org/oer-finder-plugin": "^0.0.8",
+    "@edufeed-org/oer-finder-plugin": "^0.1.0",
     "@nostr-dev-kit/ndk": "2.14.2",
     "@nostr-dev-kit/svelte": "^2.0.8",
     "@tiptap/core": "^3.13.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   nostr-tools: ~2.14.2
   '@nostr-dev-kit/ndk': ^2.14.2
-  '@edufeed-org/oer-finder-api-client': ^0.0.6
+  '@edufeed-org/oer-finder-api-client': ^0.0.7
 
 importers:
 
@@ -17,8 +17,8 @@ importers:
         specifier: ^0.0.1
         version: 0.0.1(typescript@5.9.3)(web-streams-polyfill@3.3.3)
       '@edufeed-org/oer-finder-plugin':
-        specifier: ^0.0.8
-        version: 0.0.8
+        specifier: ^0.1.0
+        version: 0.1.0
       '@nostr-dev-kit/ndk':
         specifier: ^2.14.2
         version: 2.17.4(nostr-tools@2.14.3(typescript@5.9.3))
@@ -301,11 +301,8 @@ packages:
     engines: {node: '>=20.0.0'}
     hasBin: true
 
-  '@edufeed-org/oer-finder-api-client@0.0.6':
-    resolution: {integrity: sha512-lBgDydOjqHslNQTjwvfVOPjgrftFT8BwNFJtMjDAycRx/So62ZYclX90ohak18mV2yuNLgDW0G3pC97N44zPBQ==, tarball: https://npm.pkg.github.com/download/@edufeed-org/oer-finder-api-client/0.0.6/6b1610d073cd104dcb613b1c9d5b2e9162b2060b}
-
-  '@edufeed-org/oer-finder-plugin@0.0.8':
-    resolution: {integrity: sha512-fdn5mRr6arDlQoHpuFeUxX2fujoPnxWR085uggZRxsyYKw5cipGMFTBD+VBLXmA9IvNBN6Xo/URZLuLEzv2Uwg==, tarball: https://npm.pkg.github.com/download/@edufeed-org/oer-finder-plugin/0.0.8/af7c5c1b63c2803e93b9616a26e5ac86ba236989}
+  '@edufeed-org/oer-finder-plugin@0.1.0':
+    resolution: {integrity: sha512-TDSnGhEiUruEiCis0W30CNufYkERTrjx6G9YDuFF+JNLd8CELw0SjmkeLYJc2iYXftcw9Crg9MJsc1mmirh/OQ==, tarball: https://npm.pkg.github.com/download/@edufeed-org/oer-finder-plugin/0.1.0/633da90262b91cf8256017b47cd01e1a90d45b60}
 
   '@esbuild/aix-ppc64@0.25.10':
     resolution: {integrity: sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==}
@@ -734,56 +731,67 @@ packages:
     resolution: {integrity: sha512-xRiOu9Of1FZ4SxVbB0iEDXc4ddIcjCv2aj03dmW8UrZIW7aIQ9jVJdLBIhxBI+MaTnGAKyvMwPwQnoOEvP7FgQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.52.4':
     resolution: {integrity: sha512-FbhM2p9TJAmEIEhIgzR4soUcsW49e9veAQCziwbR+XWB2zqJ12b4i/+hel9yLiD8pLncDH4fKIPIbt5238341Q==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.52.4':
     resolution: {integrity: sha512-4n4gVwhPHR9q/g8lKCyz0yuaD0MvDf7dV4f9tHt0C73Mp8h38UCtSCSE6R9iBlTbXlmA8CjpsZoujhszefqueg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.52.4':
     resolution: {integrity: sha512-u0n17nGA0nvi/11gcZKsjkLj1QIpAuPFQbR48Subo7SmZJnGxDpspyw2kbpuoQnyK+9pwf3pAoEXerJs/8Mi9g==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.52.4':
     resolution: {integrity: sha512-0G2c2lpYtbTuXo8KEJkDkClE/+/2AFPdPAbmaHoE870foRFs4pBrDehilMcrSScrN/fB/1HTaWO4bqw+ewBzMQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.52.4':
     resolution: {integrity: sha512-teSACug1GyZHmPDv14VNbvZFX779UqWTsd7KtTM9JIZRDI5NUwYSIS30kzI8m06gOPB//jtpqlhmraQ68b5X2g==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.52.4':
     resolution: {integrity: sha512-/MOEW3aHjjs1p4Pw1Xk4+3egRevx8Ji9N6HUIA1Ifh8Q+cg9dremvFCUbOX2Zebz80BwJIgCBUemjqhU5XI5Eg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.52.4':
     resolution: {integrity: sha512-1HHmsRyh845QDpEWzOFtMCph5Ts+9+yllCrREuBR/vg2RogAQGGBRC8lDPrPOMnrdOJ+mt1WLMOC2Kao/UwcvA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.52.4':
     resolution: {integrity: sha512-seoeZp4L/6D1MUyjWkOMRU6/iLmCU2EjbMTyAG4oIOs1/I82Y5lTeaxW0KBfkUdHAWN7j25bpkt0rjnOgAcQcA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.52.4':
     resolution: {integrity: sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.52.4':
     resolution: {integrity: sha512-dtBZYjDmCQ9hW+WgEkaffvRRCKm767wWhxsFW3Lw86VXz/uJRuD438/XvbZT//B96Vs8oTA8Q4A0AfHbrxP9zw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.52.4':
     resolution: {integrity: sha512-1ox+GqgRWqaB1RnyZXL8PD6E5f7YyRUJYnCqKpNzxzP0TkaUh112NDrR9Tt+C8rJ4x5G9Mk8PQR3o7Ku2RKqKA==}
@@ -955,24 +963,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.14':
     resolution: {integrity: sha512-ISZjT44s59O8xKsPEIesiIydMG/sCXoMBCqsphDm/WcbnuWLxxb+GcvSIIA5NjUw6F8Tex7s5/LM2yDy8RqYBQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.14':
     resolution: {integrity: sha512-02c6JhLPJj10L2caH4U0zF8Hji4dOeahmuMl23stk0MU1wfd1OraE7rOloidSF8W5JTHkFdVo/O7uRUJJnUAJg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.14':
     resolution: {integrity: sha512-TNGeLiN1XS66kQhxHG/7wMeQDOoL0S33x9BgmydbrWAb9Qw0KYdd8o1ifx4HOGDWhVmJ+Ul+JQ7lyknQFilO3Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.14':
     resolution: {integrity: sha512-uZYAsaW/jS/IYkd6EWPJKW/NlPNSkWkBlaeVBi/WsFQNP05/bzkebUL8FH1pdsqx4f2fH/bWFcUABOM9nfiJkQ==}
@@ -2233,24 +2245,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.1:
     resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.1:
     resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
@@ -2489,12 +2505,6 @@ packages:
 
   oniguruma-to-es@4.3.3:
     resolution: {integrity: sha512-rPiZhzC3wXwE59YQMRDodUwwT9FZ9nNBwQQfsd1wfdtlKEyCdRV0avrTcSZ5xlIvGRVPd/cx6ZN45ECmS39xvg==}
-
-  openapi-fetch@0.13.8:
-    resolution: {integrity: sha512-yJ4QKRyNxE44baQ9mY5+r/kAzZ8yXMemtNAOFwOzRXJscdjSxxzWSNlyBAr+o5JjkUw9Lc3W7OIoca0cY3PYnQ==}
-
-  openapi-typescript-helpers@0.0.15:
-    resolution: {integrity: sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -3558,13 +3568,8 @@ snapshots:
       - typescript
       - web-streams-polyfill
 
-  '@edufeed-org/oer-finder-api-client@0.0.6':
+  '@edufeed-org/oer-finder-plugin@0.1.0':
     dependencies:
-      openapi-fetch: 0.13.8
-
-  '@edufeed-org/oer-finder-plugin@0.0.8':
-    dependencies:
-      '@edufeed-org/oer-finder-api-client': 0.0.6
       lit: 3.3.1
 
   '@esbuild/aix-ppc64@0.25.10':
@@ -5824,12 +5829,6 @@ snapshots:
       oniguruma-parser: 0.12.1
       regex: 6.0.1
       regex-recursion: 6.0.2
-
-  openapi-fetch@0.13.8:
-    dependencies:
-      openapi-typescript-helpers: 0.0.15
-
-  openapi-typescript-helpers@0.0.15: {}
 
   optionator@0.9.4:
     dependencies:

--- a/src/lib/components/OerImagePicker.svelte
+++ b/src/lib/components/OerImagePicker.svelte
@@ -13,7 +13,8 @@
 		onSelect: (imageUrl: string) => void;
 	}
 
-	const apiUrl = $state(settingsStore.settings.apiUrl)
+	// Currently not used, as client side fetching is activated
+	const _apiUrl = $state(settingsStore.settings.apiUrl)
 	const language = $state(settingsStore.settings.language)
 	const { onSelect }: Props = $props();
 
@@ -67,7 +68,8 @@
 <div class="oer-picker-container">
 	<oer-search
 		bind:this={searchEl}
-		api-url={apiUrl}
+		nostr-relay-url="wss://relay.edufeed.org"
+		rpi-virtuell-api-url=""
 		language={language}
 		locked-type="image"
 		show-type-filter={false}


### PR DESCRIPTION
Das OER Finder Plugin kann nun auch lokal die Endpunkte ansprechen, was Vor- und Nachteile hat. Da das Projekt aber vor allem client side priorisieren soll, ist dies denke ich eine besser Wahl hier + Umgehung eurer Hosting Probleme.

Aktuell bekannte Probleme für später:
- Nostr AMB relay erlaubt aktuell nicht zu filtern, in Abklärung
- Am Start ist Arasaac ausgewählt im dropdown, es ist aber eigentlich openverse. Das ist noch etwas verwirrend. Hier muss noch eine default option hinzugefügt werden, die man korrekt setzen kann.