### PR TITLE
Sicherheits-Guards für Column-Patch- und Card-Events

### DIFF
--- a/docs/TO-FIX/TODO.md
+++ b/docs/TO-FIX/TODO.md
@@ -1,33 +1,161 @@
 Notwendige Fixes und ToDos für den Kanban Editor
 ===============================================
 
-## Neuer Task: Sicherheits-Guard fuer Column-Patch-Events (Kind 8571)
+## ~~Neuer Task: Sicherheits-Guard fuer Column-Patch-Events (Kind 8571)~~ ✅ DONE (2025-02-20)
 
-- Problem: Column-Patch-Events (Spaltenname/-farbe/-reihenfolge) werden aktuell ohne harten Rollencheck angewendet.
-- Risiko: Fremde Publisher koennen potenziell Spalten-Metadaten beeinflussen, wenn Event-Filter greifen.
-- Ziel: Inbound-Patch nur akzeptieren, wenn `event.pubkey` entweder `board.author` oder in `board.maintainers` enthalten ist.
-- Umsetzung:
-  - Guard im Patch-Handler/Apply-Pfad einbauen (`publisherPubkey` verbindlich validieren).
-  - Ungueltige Events mit Debug/Warn skippen (kein Apply, kein local persist).
-  - Vorhandene Owner-only-Regel fuer 30301 unveraendert lassen.
-- Tests:
-  - `editor`-Patch wird angewendet.
-  - `owner`-Patch wird angewendet.
-  - Fremder Pubkey wird verworfen.
-  - LWW-Verhalten bleibt intakt.
+- ✅ Guard in `columnOrderPatch.ts` nach Board-Zugehoerigkeits-Check eingefuegt
+- ✅ Nutzt `currentBoard.isMaintainer(event.pubkey)` — Owner + Maintainers akzeptiert, Fremde rejected
+- ✅ Guard nur aktiv wenn `currentBoard.author` gesetzt (kein Breaking Change fuer lokale Boards)
+- ✅ Tests: `columnOrderPatch.authorization.spec.ts` (11 Tests, alle gruen)
 
-## Neuer Task: Sicherheits-Guard fuer Card-Events (Kind 30302)
+## ~~Neuer Task: Sicherheits-Guard fuer Card-Events (Kind 30302)~~ ✅ DONE (2025-02-20)
 
-- Problem: Card-Events werden aktuell ohne harten Publisher-Rollencheck verarbeitet.
-- Risiko: Fremde Publisher koennen Card-Inhalte, Positionen (rank/column) oder Loeschungen im Client beeinflussen.
-- Ziel: Inbound-Card nur akzeptieren, wenn `event.pubkey` entweder `board.author` oder in `board.maintainers` enthalten ist.
-- Optional: `card.author` nicht als harte Sperre fuer Updates erzwingen, damit Maintainer kollaborativ alle Cards bearbeiten koennen.
-- Umsetzung:
-  - Guard in `handleCardEvent` vor `upsertCardFromNostr()` / `upsertCardToBackgroundBoard()` einbauen.
-  - Ungueltige Events mit Debug/Warn skippen (kein Apply, kein local persist).
-  - Bestehende LWW-/Tie-Break-Logik unveraendert lassen.
-- Tests:
-  - Owner-Card-Update wird angewendet.
-  - Maintainer-Card-Update wird angewendet.
-  - Fremder Pubkey wird verworfen.
-  - Background-Board-Sync respektiert den Guard.
+- ✅ Guard in `card.ts` vor `upsertCardFromNostr()` / `upsertCardToBackgroundBoard()` eingefuegt
+- ✅ Current-Board + Background-Board Guards (Background via `BoardStorage.loadBoard()`)
+- ✅ Nutzt `board.isMaintainer(event.pubkey)` — Maintainer koennen kollaborativ alle Cards bearbeiten
+- ✅ Guard nur aktiv wenn `board.author` gesetzt; Background-Board ohne lokale Kopie → Guard uebersprungen
+- ✅ Tests: `card.authorization.spec.ts` (12 Tests, alle gruen)
+
+
+## Lösungsvorschlag: Sicherheits-Guards für Kind 8571 & Kind 30302
+
+Beide Event-Handler (Column-Patch und Card) nehmen aktuell Events von **jedem** Publisher an. Das Ziel: Inbound-Events nur akzeptieren, wenn `event.pubkey` entweder `board.author` oder in `board.maintainers` enthalten ist. Die bestehende Methode `Board.isMaintainer(pubkey)` (BoardModel.ts) deckt beides ab und wird als zentrale Prüfung genutzt.
+
+**Steps**
+
+### 1. Guard in Column-Patch-Handler einfügen
+
+**Datei:** columnOrderPatch.ts
+
+- **Wo:** Nach dem Board-Zugehörigkeits-Check (~Zeile 54, nach `if (!aOk && !dOk)`) und **vor** dem `boardStore.applyColumnOrderPatchFromNostr()`-Aufruf (~Zeile 105).
+- **Was:** Neuer Block, der `currentBoard.isMaintainer(event.pubkey)` prüft. Wenn `currentBoard.author` gesetzt ist (= Nostr-Board) und der Pubkey kein Maintainer ist → `return false` mit Debug-Log.
+- **Edge-Case:** Wenn `currentBoard.author` leer/undefined ist (lokales Board ohne Nostr), wird der Guard übersprungen — kein Breaking Change für Offline-Boards.
+
+### 2. Guard in Card-Event-Handler einfügen
+
+**Datei:** card.ts
+
+- **Wo:** Im `try`-Block, **nach** der Ermittlung von `targetBoardId` (~Zeile 79) und **vor** den `upsertCardFromNostr()` / `upsertCardToBackgroundBoard()`-Aufrufen (~Zeile 128-133).
+- **Was:** Zwei Pfade je nach Ziel-Board:
+  - **Current Board** (`targetBoardId === currentBoard.id`): Prüfe `currentBoard.isMaintainer(cardEvent.pubkey)`.
+  - **Background Board** (`targetBoardId !== currentBoard.id`): Lade Board via `BoardStorage.loadBoard(targetBoardId)` und prüfe `loadedBoard.isMaintainer(cardEvent.pubkey)`. Wenn Board nicht ladbar → Guard überspringen (Board existiert lokal nicht, kein Referenz-Author bekannt).
+- **Edge-Case:** Wie bei 8571 — Guard nur aktiv wenn `board.author` gesetzt ist.
+
+### 3. Tests für Column-Patch-Guard
+
+**Neue Datei:** `src/lib/stores/boardstore/nostr/handlers/columnOrderPatch.authorization.spec.ts`
+
+Test-Pattern analog zu board.lww-shared.spec.ts: Board-Mock mit `author` + `maintainers`, fake Events mit verschiedenen Pubkeys.
+
+**Test-Cases:**
+1. **Owner-Patch wird angewendet** — `event.pubkey === board.author` → `applyColumnOrderPatchFromNostr` wird aufgerufen.
+2. **Maintainer-Patch wird angewendet** — `event.pubkey` in `board.maintainers` → wird aufgerufen.
+3. **Fremder Pubkey wird verworfen** — `event.pubkey` ist weder Owner noch Maintainer → `return false`, Store-Methode nicht aufgerufen.
+4. **Lokales Board (kein author)** — `board.author` ist `undefined` → Guard wird übersprungen, Patch wird angewendet.
+5. **LWW-Verhalten intakt** — bestehende Tests in kanbanStore.columnPatch.spec.ts bleiben grün.
+
+### 4. Tests für Card-Guard
+
+**Neue Datei:** `src/lib/stores/boardstore/nostr/handlers/card.authorization.spec.ts`
+
+Gleicher Mock-Ansatz wie card.lww-ms.spec.ts: `createBoardMock` erweitern um `author`, `maintainers` und `isMaintainer()`.
+
+**Test-Cases:**
+1. **Owner-Card-Update wird angewendet** — `event.pubkey === board.author` → `upsertCardFromNostr` aufgerufen.
+2. **Maintainer-Card-Update wird angewendet** — `event.pubkey` in `board.maintainers` → aufgerufen.
+3. **Fremder Pubkey wird verworfen** — weder Owner noch Maintainer → kein Aufruf, kein Error.
+4. **Background-Board-Sync respektiert Guard** — Background-Board mit `author` geladen, fremder Pubkey → `upsertCardToBackgroundBoard` nicht aufgerufen.
+5. **Lokales Board (kein author)** — Guard übersprungen, Card wird normal verarbeitet.
+
+### 5. TODO.md aktualisieren
+
+Beide Tasks in TODO.md nach Implementierung als erledigt markieren.
+
+**Verification**
+- `pnpm run test:unit` — alle bestehenden Tests + neue Guard-Tests grün
+- `pnpm run check` — TypeScript-Checks bestehen
+- Manuelle Verifikation: In der Browser-Konsole prüfen, dass bei fremden Events ein `[ColumnOrderPatch] rejected` bzw. `[CardEvent] rejected` Debug-Log erscheint
+
+**Decisions**
+- **Guard-Platzierung im Handler (nicht im Store):** Konsistent mit dem bestehenden Board-Guard in board.ts. Der Handler ist die richtige Schicht für Autorisierung — der Store bleibt "dumb".
+- **`isMaintainer()` statt manueller Prüfung:** Die Methode existiert bereits und deckt Owner + Maintainers ab. Kein neuer Code im Model nötig.
+- **Guard nur aktiv wenn `board.author` gesetzt:** Verhindert Breaking Changes für rein lokale Boards ohne Nostr-Anbindung.
+- **Background-Board via `BoardStorage.loadBoard()`:** Für Card-Events, die nicht für das aktive Board bestimmt sind, wird das Ziel-Board aus localStorage geladen. Wenn nicht vorhanden → Guard übersprungen (kein Referenz-Author bekannt, kann nicht validieren).
+
+
+---
+
+## PR Description
+
+### Authorization Guards for Inbound Nostr Events (Kind 8571 & 30302)
+
+**Problem**
+
+Column-Patch-Events (Kind 8571) und Card-Events (Kind 30302) wurden bisher ohne Publisher-Rollencheck verarbeitet. Jeder Nostr-Nutzer, dessen Events die Relay-Filter passieren, konnte potenziell Spalten-Metadaten (Name, Farbe, Reihenfolge) und Card-Inhalte (Titel, Beschreibung, Position, Löschung) im lokalen Client beeinflussen.
+
+Der Board-Event-Handler (Kind 30301) hatte bereits einen Owner-only Guard — dieser PR schliesst die Lücke für die beiden anderen Event-Typen.
+
+**Solution**
+
+Autorisierungs-Guards in beiden Event-Handlern, konsistent mit dem bestehenden Pattern in `board.ts`:
+
+- **Column-Patch (Kind 8571):** Guard in `columnOrderPatch.ts` nach Board-Zugehoerigkeits-Check. Nutzt `currentBoard.isMaintainer(event.pubkey)` — akzeptiert Owner + Maintainers, rejected alle anderen mit Debug-Log.
+- **Card (Kind 30302):** Guard in `card.ts` vor `upsertCardFromNostr()` / `upsertCardToBackgroundBoard()`. Zwei Pfade:
+  - Current Board: prüft `currentBoard.isMaintainer(eventPubkey)`
+  - Background Board: lädt Board via `BoardStorage.loadBoard()`, prüft `backgroundBoard.isMaintainer(eventPubkey)`. Board lokal nicht vorhanden → Guard übersprungen.
+
+Kein neuer Code im Model — die bestehende `Board.isMaintainer(pubkey)` Methode deckt Owner + Maintainers ab.
+
+**Design Decisions**
+
+- Guards nur aktiv wenn `board.author` gesetzt ist → kein Breaking Change für rein lokale Offline-Boards
+- Guard-Platzierung im Handler (nicht im Store) — konsistent mit `board.ts`, Handler ist die richtige Autorisierungs-Schicht
+- `card.author` wird bewusst **nicht** als harte Sperre erzwungen → Maintainer können kollaborativ alle Cards bearbeiten
+- Ungültige Events werden silent mit `console.debug` geloggt (kein Error, kein Apply, kein local persist)
+
+**Changed Files**
+
+| Datei | Änderung |
+|-------|----------|
+| `src/lib/stores/boardstore/nostr/handlers/columnOrderPatch.ts` | Authorization Guard eingefügt (Owner + Maintainers) |
+| `src/lib/stores/boardstore/nostr/handlers/card.ts` | Authorization Guard für Current- und Background-Board eingefügt |
+| `src/lib/stores/boardstore/nostr/handlers/columnOrderPatch.authorization.spec.ts` | **Neu** — 11 Tests |
+| `src/lib/stores/boardstore/nostr/handlers/card.authorization.spec.ts` | **Neu** — 12 Tests |
+| `docs/TO-FIX/TODO.md` | Tasks als erledigt markiert |
+
+**Test Coverage (23 neue Tests)**
+
+Column-Patch Guard (11 Tests):
+- Owner-Patch akzeptiert
+- Maintainer-Patch akzeptiert
+- Fremder Pubkey verworfen
+- Lokales Board ohne author → Guard übersprungen
+- Leerer author-String → Guard übersprungen
+- Fehlender event.pubkey → Guard übersprungen
+- Zweiter Maintainer akzeptiert
+- Deduplication intakt neben Guard
+- Board-Mismatch greift weiterhin vor Guard
+- Fallback wenn `isMaintainer` keine Funktion (plain object)
+- Stranger rejected mit Fallback
+
+Card Guard (12 Tests):
+- Owner-Card-Update akzeptiert
+- Maintainer-Card-Update akzeptiert
+- Fremder Pubkey verworfen
+- Lokales Board ohne author → Guard übersprungen
+- Fehlender event.pubkey → Guard übersprungen
+- Zweiter Maintainer akzeptiert
+- Background-Board: Owner akzeptiert
+- Background-Board: Maintainer akzeptiert
+- Background-Board: Stranger rejected
+- Background-Board ohne author → Guard übersprungen
+- Background-Board lokal nicht vorhanden → Guard übersprungen, Event trotzdem gespeichert
+- LWW-Skip funktioniert weiterhin neben Guard
+
+**Verification**
+
+```bash
+pnpm run test:unit  # 38/38 Handler-Tests grün (inkl. 23 neue)
+```
+
+Keine Regressionen in bestehenden Tests (`board.lww-shared.spec.ts`, `card.lww-ms.spec.ts`, `deletion.spec.ts`).

--- a/src/lib/stores/boardstore/nostr/handlers/card.authorization.spec.ts
+++ b/src/lib/stores/boardstore/nostr/handlers/card.authorization.spec.ts
@@ -1,0 +1,293 @@
+/**
+ * Tests für Sicherheits-Guard in handleCardEvent()
+ *
+ * Validiert, dass Card-Events (Kind 30302) nur akzeptiert werden,
+ * wenn event.pubkey entweder board.author oder in board.maintainers ist.
+ *
+ * Deckt ab:
+ * - Owner-Card-Update wird angewendet
+ * - Maintainer-Card-Update wird angewendet
+ * - Fremder Pubkey wird verworfen
+ * - Background-Board-Sync respektiert den Guard
+ * - Lokale Boards ohne author → Guard übersprungen
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { handleCardEvent } from './card';
+
+const OWNER_PUBKEY = 'owner-pubkey-hex-0000';
+const EDITOR_PUBKEY = 'editor-pubkey-hex-1111';
+const STRANGER_PUBKEY = 'stranger-pubkey-hex-9999';
+
+// Mock BoardStorage for background board tests
+vi.mock('../../storage.js', () => {
+	let _mockBoard: any = null;
+	return {
+		BoardStorage: {
+			loadBoard: vi.fn(() => _mockBoard),
+			saveBoard: vi.fn(),
+			__setMockBoard: (board: any) => { _mockBoard = board; },
+		},
+	};
+});
+
+function createBoard(overrides?: {
+	author?: string;
+	maintainers?: string[];
+	cardUpdatedAt?: string;
+	cardEventId?: string;
+}) {
+	const author = overrides?.author ?? OWNER_PUBKEY;
+	const maintainers = overrides?.maintainers ?? [EDITOR_PUBKEY];
+
+	return {
+		id: 'board-1',
+		author,
+		maintainers,
+		isMaintainer(pubkey: string): boolean {
+			if (!pubkey) return false;
+			return pubkey === author || maintainers.includes(pubkey);
+		},
+		findCardAndColumn: vi.fn(() => {
+			if (overrides?.cardUpdatedAt) {
+				return {
+					card: {
+						id: 'card-1',
+						updatedAt: overrides.cardUpdatedAt,
+						eventId: overrides.cardEventId,
+					},
+					column: { id: 'col-1' },
+				};
+			}
+			return null;
+		}),
+	};
+}
+
+function createBackgroundBoard(overrides?: {
+	author?: string;
+	maintainers?: string[];
+}) {
+	const author = overrides?.author ?? OWNER_PUBKEY;
+	const maintainers = overrides?.maintainers ?? [EDITOR_PUBKEY];
+	return {
+		id: 'bg-board-1',
+		author,
+		maintainers,
+		isMaintainer(pubkey: string): boolean {
+			if (!pubkey) return false;
+			return pubkey === author || maintainers.includes(pubkey);
+		},
+		markAsChanged: vi.fn(),
+	};
+}
+
+function createCardEvent(pubkey: string, overrides?: {
+	id?: string;
+	boardRef?: string;
+	columnId?: string;
+}) {
+	const boardRef = overrides?.boardRef ?? `30301:${OWNER_PUBKEY}:board-1`;
+	return {
+		id: overrides?.id ?? `card-event-${pubkey.slice(0, 8)}-${Date.now()}`,
+		kind: 30302,
+		pubkey,
+		created_at: Math.floor(Date.now() / 1000),
+		tags: [
+			['d', 'card-1'],
+			['a', boardRef],
+			['s', overrides?.columnId ?? 'col-1'],
+			['rank', '0'],
+			['ts', String(Date.now())],
+		],
+		content: 'Card content',
+	};
+}
+
+function createCtx() {
+	return {
+		processedEvents: new Set<string>(),
+		cardDeletionTimestamps: new Map<string, number>(),
+		syncManager: {
+			isMyEvent: vi.fn(() => false),
+			clearMyEvent: vi.fn(),
+		},
+	};
+}
+
+function createBoardStore() {
+	return {
+		upsertCardFromNostr: vi.fn(),
+		upsertCardToBackgroundBoard: vi.fn(),
+	};
+}
+
+describe('handleCardEvent Authorization Guard', () => {
+	let ctx: ReturnType<typeof createCtx>;
+	let boardStore: ReturnType<typeof createBoardStore>;
+	let BoardStorageMock: any;
+
+	beforeEach(async () => {
+		ctx = createCtx();
+		boardStore = createBoardStore();
+		// Access the mock to control background board
+		BoardStorageMock = await import('../../storage.js');
+		(BoardStorageMock.BoardStorage as any).__setMockBoard(null);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	// --- Current Board Tests ---
+
+	it('accepts card event from board owner', async () => {
+		const board = createBoard();
+		const event = createCardEvent(OWNER_PUBKEY);
+
+		await handleCardEvent(ctx as any, event as any, board as any, boardStore);
+
+		expect(boardStore.upsertCardFromNostr).toHaveBeenCalledTimes(1);
+	});
+
+	it('accepts card event from maintainer', async () => {
+		const board = createBoard();
+		const event = createCardEvent(EDITOR_PUBKEY);
+
+		await handleCardEvent(ctx as any, event as any, board as any, boardStore);
+
+		expect(boardStore.upsertCardFromNostr).toHaveBeenCalledTimes(1);
+	});
+
+	it('rejects card event from unauthorized pubkey', async () => {
+		const board = createBoard();
+		const event = createCardEvent(STRANGER_PUBKEY);
+
+		await handleCardEvent(ctx as any, event as any, board as any, boardStore);
+
+		expect(boardStore.upsertCardFromNostr).not.toHaveBeenCalled();
+		expect(boardStore.upsertCardToBackgroundBoard).not.toHaveBeenCalled();
+	});
+
+	it('skips guard for local boards without author', async () => {
+		const board = createBoard({ author: '' });
+		const event = createCardEvent(STRANGER_PUBKEY);
+
+		await handleCardEvent(ctx as any, event as any, board as any, boardStore);
+
+		// Guard skipped → event accepted regardless of pubkey
+		expect(boardStore.upsertCardFromNostr).toHaveBeenCalledTimes(1);
+	});
+
+	it('skips guard when event.pubkey is missing', async () => {
+		const board = createBoard();
+		const event = createCardEvent(OWNER_PUBKEY);
+		delete (event as any).pubkey;
+
+		await handleCardEvent(ctx as any, event as any, board as any, boardStore);
+
+		// publisherPubkey is '' → guard condition is false → skip guard
+		expect(boardStore.upsertCardFromNostr).toHaveBeenCalledTimes(1);
+	});
+
+	it('accepts second maintainer', async () => {
+		const secondEditor = 'editor-2-pubkey';
+		const board = createBoard({ maintainers: [EDITOR_PUBKEY, secondEditor] });
+		const event = createCardEvent(secondEditor);
+
+		await handleCardEvent(ctx as any, event as any, board as any, boardStore);
+
+		expect(boardStore.upsertCardFromNostr).toHaveBeenCalledTimes(1);
+	});
+
+	// --- Background Board Tests ---
+
+	it('accepts card event for background board from owner', async () => {
+		const board = createBoard(); // current board
+		const bgBoard = createBackgroundBoard();
+		(BoardStorageMock.BoardStorage as any).__setMockBoard(bgBoard);
+
+		const event = createCardEvent(OWNER_PUBKEY, {
+			boardRef: `30301:${OWNER_PUBKEY}:bg-board-1`,
+		});
+
+		await handleCardEvent(ctx as any, event as any, board as any, boardStore);
+
+		expect(boardStore.upsertCardToBackgroundBoard).toHaveBeenCalledTimes(1);
+		expect(bgBoard.markAsChanged).toHaveBeenCalledTimes(1);
+	});
+
+	it('accepts card event for background board from maintainer', async () => {
+		const board = createBoard();
+		const bgBoard = createBackgroundBoard();
+		(BoardStorageMock.BoardStorage as any).__setMockBoard(bgBoard);
+
+		const event = createCardEvent(EDITOR_PUBKEY, {
+			boardRef: `30301:${OWNER_PUBKEY}:bg-board-1`,
+		});
+
+		await handleCardEvent(ctx as any, event as any, board as any, boardStore);
+
+		expect(boardStore.upsertCardToBackgroundBoard).toHaveBeenCalledTimes(1);
+	});
+
+	it('rejects card event for background board from stranger', async () => {
+		const board = createBoard();
+		const bgBoard = createBackgroundBoard();
+		(BoardStorageMock.BoardStorage as any).__setMockBoard(bgBoard);
+
+		const event = createCardEvent(STRANGER_PUBKEY, {
+			boardRef: `30301:${OWNER_PUBKEY}:bg-board-1`,
+		});
+
+		await handleCardEvent(ctx as any, event as any, board as any, boardStore);
+
+		expect(boardStore.upsertCardToBackgroundBoard).not.toHaveBeenCalled();
+	});
+
+	it('skips guard for background board without author', async () => {
+		const board = createBoard();
+		const bgBoard = createBackgroundBoard({ author: '' });
+		(BoardStorageMock.BoardStorage as any).__setMockBoard(bgBoard);
+
+		const event = createCardEvent(STRANGER_PUBKEY, {
+			boardRef: `30301:${OWNER_PUBKEY}:bg-board-1`,
+		});
+
+		await handleCardEvent(ctx as any, event as any, board as any, boardStore);
+
+		// Guard skipped → event accepted
+		expect(boardStore.upsertCardToBackgroundBoard).toHaveBeenCalledTimes(1);
+	});
+
+	it('allows background board sync when board not found locally', async () => {
+		const board = createBoard();
+		// BoardStorage.loadBoard returns null (no mock board set)
+		(BoardStorageMock.BoardStorage as any).__setMockBoard(null);
+
+		const event = createCardEvent(STRANGER_PUBKEY, {
+			boardRef: `30301:someone:unknown-board`,
+		});
+
+		await handleCardEvent(ctx as any, event as any, board as any, boardStore);
+
+		// Board not found locally → can't validate → still accepted
+		expect(boardStore.upsertCardToBackgroundBoard).toHaveBeenCalledTimes(1);
+	});
+
+	// --- LWW still works alongside guard ---
+
+	it('LWW skip still works for authorized users', async () => {
+		// Board with an existing card that has a newer timestamp
+		const board = createBoard({
+			cardUpdatedAt: new Date('2030-01-01T00:00:00Z').toISOString(),
+		});
+		const event = createCardEvent(OWNER_PUBKEY);
+		// Event created_at is "now" which is before 2030 → LWW should skip
+
+		await handleCardEvent(ctx as any, event as any, board as any, boardStore);
+
+		// Even though owner is authorized, LWW rejects because local is newer
+		expect(boardStore.upsertCardFromNostr).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/stores/boardstore/nostr/handlers/card.ts
+++ b/src/lib/stores/boardstore/nostr/handlers/card.ts
@@ -122,20 +122,52 @@ export async function handleCardEvent(
 			return;
 		}
 
+		// 🔒 Authorization Guard: Nur Owner + Maintainers dürfen Card-Events anwenden
+		const eventPubkey = typeof cardEvent.pubkey === 'string' ? cardEvent.pubkey : '';
+
 		// ⚡ v3.0: CRITICAL - Support Background Board Sync
 		// Wenn Card für aktuelles Board → normale Verarbeitung
 		// Wenn Card für Background Board → speichere direkt in localStorage
 		if (targetBoardId === currentBoard.id) {
+			// 🔒 Guard für aktuelles Board
+			if (currentBoard.author && eventPubkey) {
+				const authorized = typeof currentBoard.isMaintainer === 'function'
+					? currentBoard.isMaintainer(eventPubkey)
+					: eventPubkey === currentBoard.author;
+				if (!authorized) {
+					console.debug('[CardEvent] rejected (unauthorized pubkey)', {
+						pubkey: eventPubkey.slice(0, 12) + '...',
+						boardId: currentBoard.id,
+					});
+					return;
+				}
+			}
+
 			console.log(`✅ Card ${cardProps.id} ist für aktuelles Board - normale Verarbeitung`);
 			boardStore.upsertCardFromNostr(cardProps);
 		} else {
-			boardStore.upsertCardToBackgroundBoard(targetBoardId, cardProps);
-
-			// ⚡ NEW: Set unseen changes flag for background board
+			// 🔒 Guard für Background-Board
 			const backgroundBoard = BoardStorage.loadBoard(targetBoardId);
 			if (backgroundBoard) {
+				if (backgroundBoard.author && eventPubkey) {
+					const authorized = typeof backgroundBoard.isMaintainer === 'function'
+						? backgroundBoard.isMaintainer(eventPubkey)
+						: eventPubkey === backgroundBoard.author;
+					if (!authorized) {
+						console.debug('[CardEvent] rejected for background board (unauthorized pubkey)', {
+							pubkey: eventPubkey.slice(0, 12) + '...',
+							boardId: targetBoardId,
+						});
+						return;
+					}
+				}
+
+				boardStore.upsertCardToBackgroundBoard(targetBoardId, cardProps);
 				backgroundBoard.markAsChanged();
 				BoardStorage.saveBoard(backgroundBoard);
+			} else {
+				// Board existiert lokal nicht — kann nicht validieren, trotzdem speichern
+				boardStore.upsertCardToBackgroundBoard(targetBoardId, cardProps);
 			}
 		}
 	} catch (error) {

--- a/src/lib/stores/boardstore/nostr/handlers/columnOrderPatch.authorization.spec.ts
+++ b/src/lib/stores/boardstore/nostr/handlers/columnOrderPatch.authorization.spec.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests für Sicherheits-Guard in handleColumnOrderPatchEvent()
+ *
+ * Validiert, dass Column-Patch-Events (Kind 8571) nur akzeptiert werden,
+ * wenn event.pubkey entweder board.author oder in board.maintainers ist.
+ *
+ * Guard-Logik: currentBoard.isMaintainer(event.pubkey)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleColumnOrderPatchEvent } from './columnOrderPatch';
+
+// Mock EVENT_KINDS
+vi.mock('$lib/utils/nostrEvents.js', () => ({
+	EVENT_KINDS: { COLUMN_ORDER_PATCH: 8571 },
+}));
+
+const OWNER_PUBKEY = 'owner-pubkey-hex-0000';
+const EDITOR_PUBKEY = 'editor-pubkey-hex-1111';
+const STRANGER_PUBKEY = 'stranger-pubkey-hex-9999';
+
+function createBoard(overrides?: { author?: string; maintainers?: string[] }) {
+	const author = overrides && 'author' in overrides ? overrides.author : OWNER_PUBKEY;
+	const maintainers = overrides?.maintainers ?? [EDITOR_PUBKEY];
+	return {
+		id: 'board-1',
+		author,
+		maintainers,
+		isMaintainer(pubkey: string): boolean {
+			if (!pubkey) return false;
+			return pubkey === author || maintainers.includes(pubkey);
+		},
+	};
+}
+
+function createPatchEvent(pubkey: string, id?: string) {
+	return {
+		id: id ?? `patch-event-${pubkey.slice(0, 8)}`,
+		kind: 8571,
+		pubkey,
+		created_at: Math.floor(Date.now() / 1000),
+		tags: [
+			['a', `30301:${OWNER_PUBKEY}:board-1`],
+			['d', 'board-1'],
+			['order', 'col-1', 'col-2'],
+			['updated_at_ms', String(Date.now())],
+		],
+	};
+}
+
+function createCtx() {
+	return { processedEvents: new Set<string>() };
+}
+
+function createBoardStore() {
+	return {
+		applyColumnOrderPatchFromNostr: vi.fn(() => true),
+	};
+}
+
+describe('handleColumnOrderPatchEvent Authorization Guard', () => {
+	let ctx: ReturnType<typeof createCtx>;
+	let boardStore: ReturnType<typeof createBoardStore>;
+
+	beforeEach(() => {
+		ctx = createCtx();
+		boardStore = createBoardStore();
+	});
+
+	it('accepts patch from board owner', async () => {
+		const board = createBoard();
+		const event = createPatchEvent(OWNER_PUBKEY);
+
+		const result = await handleColumnOrderPatchEvent(ctx, event, board, boardStore);
+
+		expect(result).toBe(true);
+		expect(boardStore.applyColumnOrderPatchFromNostr).toHaveBeenCalledTimes(1);
+	});
+
+	it('accepts patch from maintainer (editor)', async () => {
+		const board = createBoard();
+		const event = createPatchEvent(EDITOR_PUBKEY);
+
+		const result = await handleColumnOrderPatchEvent(ctx, event, board, boardStore);
+
+		expect(result).toBe(true);
+		expect(boardStore.applyColumnOrderPatchFromNostr).toHaveBeenCalledTimes(1);
+	});
+
+	it('rejects patch from unauthorized pubkey', async () => {
+		const board = createBoard();
+		const event = createPatchEvent(STRANGER_PUBKEY);
+
+		const result = await handleColumnOrderPatchEvent(ctx, event, board, boardStore);
+
+		expect(result).toBe(false);
+		expect(boardStore.applyColumnOrderPatchFromNostr).not.toHaveBeenCalled();
+	});
+
+	it('skips guard for local boards without author (author undefined)', async () => {
+		const board = createBoard({ author: undefined as any });
+		const event = createPatchEvent(STRANGER_PUBKEY);
+
+		// Adjust a-tag so board-mismatch check passes
+		event.tags[0] = ['a', `30301:someone:board-1`];
+
+		const result = await handleColumnOrderPatchEvent(ctx, event, board, boardStore);
+
+		// Guard skipped because board.author is falsy → patch accepted
+		expect(result).toBe(true);
+		expect(boardStore.applyColumnOrderPatchFromNostr).toHaveBeenCalledTimes(1);
+	});
+
+	it('skips guard for local boards without author (author empty string)', async () => {
+		const board = createBoard({ author: '' });
+		const event = createPatchEvent(STRANGER_PUBKEY);
+
+		event.tags[0] = ['a', `30301:someone:board-1`];
+
+		const result = await handleColumnOrderPatchEvent(ctx, event, board, boardStore);
+
+		expect(result).toBe(true);
+		expect(boardStore.applyColumnOrderPatchFromNostr).toHaveBeenCalledTimes(1);
+	});
+
+	it('skips guard when event.pubkey is missing', async () => {
+		const board = createBoard();
+		const event = createPatchEvent(OWNER_PUBKEY);
+		delete (event as any).pubkey;
+
+		const result = await handleColumnOrderPatchEvent(ctx, event, board, boardStore);
+
+		// publisherPubkey is '' → guard condition (currentBoard.author && publisherPubkey) is false → skip
+		expect(result).toBe(true);
+		expect(boardStore.applyColumnOrderPatchFromNostr).toHaveBeenCalledTimes(1);
+	});
+
+	it('accepts second maintainer in list', async () => {
+		const secondEditor = 'editor-2-pubkey-hex';
+		const board = createBoard({ maintainers: [EDITOR_PUBKEY, secondEditor] });
+		const event = createPatchEvent(secondEditor);
+
+		const result = await handleColumnOrderPatchEvent(ctx, event, board, boardStore);
+
+		expect(result).toBe(true);
+		expect(boardStore.applyColumnOrderPatchFromNostr).toHaveBeenCalledTimes(1);
+	});
+
+	it('existing dedup still works alongside guard', async () => {
+		const board = createBoard();
+		const event = createPatchEvent(OWNER_PUBKEY, 'same-id');
+
+		// First call: accepted
+		const result1 = await handleColumnOrderPatchEvent(ctx, event, board, boardStore);
+		expect(result1).toBe(true);
+
+		// Second call: deduplicated (already processed)
+		const result2 = await handleColumnOrderPatchEvent(ctx, event, board, boardStore);
+		expect(result2).toBe(false);
+		expect(boardStore.applyColumnOrderPatchFromNostr).toHaveBeenCalledTimes(1);
+	});
+
+	it('board-mismatch check still fires before guard', async () => {
+		const board = createBoard();
+		const event = createPatchEvent(OWNER_PUBKEY);
+		// Wrong board reference
+		event.tags = [
+			['a', '30301:someone:different-board'],
+			['d', 'different-board'],
+			['order', 'col-1'],
+		];
+
+		const result = await handleColumnOrderPatchEvent(ctx, event, board, boardStore);
+
+		expect(result).toBe(false);
+		expect(boardStore.applyColumnOrderPatchFromNostr).not.toHaveBeenCalled();
+	});
+
+	it('works with fallback when isMaintainer is not a function', async () => {
+		// Board without isMaintainer method (plain object)
+		const board = {
+			id: 'board-1',
+			author: OWNER_PUBKEY,
+		};
+		const event = createPatchEvent(OWNER_PUBKEY);
+
+		const result = await handleColumnOrderPatchEvent(ctx, event, board, boardStore);
+
+		expect(result).toBe(true);
+		expect(boardStore.applyColumnOrderPatchFromNostr).toHaveBeenCalledTimes(1);
+	});
+
+	it('rejects stranger even with fallback when isMaintainer is not a function', async () => {
+		const board = {
+			id: 'board-1',
+			author: OWNER_PUBKEY,
+		};
+		const event = createPatchEvent(STRANGER_PUBKEY);
+
+		const result = await handleColumnOrderPatchEvent(ctx, event, board, boardStore);
+
+		expect(result).toBe(false);
+		expect(boardStore.applyColumnOrderPatchFromNostr).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/stores/boardstore/nostr/handlers/columnOrderPatch.ts
+++ b/src/lib/stores/boardstore/nostr/handlers/columnOrderPatch.ts
@@ -51,6 +51,22 @@ export async function handleColumnOrderPatchEvent(
 		return false;
 	}
 
+	// 🔒 Authorization Guard: Nur Owner + Maintainers dürfen Column-Patches anwenden
+	const publisherPubkey = typeof event.pubkey === 'string' ? event.pubkey : '';
+	if (currentBoard.author && publisherPubkey) {
+		const isMaintainer = typeof currentBoard.isMaintainer === 'function'
+			? currentBoard.isMaintainer(publisherPubkey)
+			: publisherPubkey === currentBoard.author;
+		if (!isMaintainer) {
+			console.debug('[ColumnOrderPatch] rejected (unauthorized pubkey)', {
+				id: event.id,
+				pubkey: publisherPubkey.slice(0, 12) + '...',
+				boardId,
+			});
+			return false;
+		}
+	}
+
 	const columnOrder: string[] = Array.isArray(orderTag)
 		? orderTag.slice(1).filter((v) => typeof v === 'string')
 		: [];


### PR DESCRIPTION
**Problem**

Column-Patch-Events (Kind 8571) und Card-Events (Kind 30302) wurden bisher ohne Publisher-Rollencheck verarbeitet. Jeder Nostr-Nutzer, dessen Events die Relay-Filter passieren, konnte potenziell Spalten-Metadaten (Name, Farbe, Reihenfolge) und Card-Inhalte (Titel, Beschreibung, Position, Löschung) im lokalen Client beeinflussen. 

- #114
- #115

Der Board-Event-Handler (Kind 30301) hatte bereits einen Owner-only Guard — dieser PR schliesst die Lücke für die beiden anderen Event-Typen.

**Solution**

Autorisierungs-Guards in beiden Event-Handlern, konsistent mit dem bestehenden Pattern in `board.ts`:

- **Column-Patch (Kind 8571):** Guard in `columnOrderPatch.ts` nach Board-Zugehoerigkeits-Check. Nutzt `currentBoard.isMaintainer(event.pubkey)` — akzeptiert Owner + Maintainers, rejected alle anderen mit Debug-Log.
- **Card (Kind 30302):** Guard in `card.ts` vor `upsertCardFromNostr()` / `upsertCardToBackgroundBoard()`. Zwei Pfade:
  - Current Board: prüft `currentBoard.isMaintainer(eventPubkey)`
  - Background Board: lädt Board via `BoardStorage.loadBoard()`, prüft `backgroundBoard.isMaintainer(eventPubkey)`. Board lokal nicht vorhanden → Guard übersprungen.

Kein neuer Code im Model — die bestehende `Board.isMaintainer(pubkey)` Methode deckt Owner + Maintainers ab.

**Design Decisions**

- Guards nur aktiv wenn `board.author` gesetzt ist → kein Breaking Change für rein lokale Offline-Boards
- Guard-Platzierung im Handler (nicht im Store) — konsistent mit `board.ts`, Handler ist die richtige Autorisierungs-Schicht
- `card.author` wird bewusst **nicht** als harte Sperre erzwungen → Maintainer können kollaborativ alle Cards bearbeiten
- Ungültige Events werden silent mit `console.debug` geloggt (kein Error, kein Apply, kein local persist)

**Changed Files**

| Datei | Änderung |
|-------|----------|
| `src/lib/stores/boardstore/nostr/handlers/columnOrderPatch.ts` | Authorization Guard eingefügt (Owner + Maintainers) |
| `src/lib/stores/boardstore/nostr/handlers/card.ts` | Authorization Guard für Current- und Background-Board eingefügt |
| `src/lib/stores/boardstore/nostr/handlers/columnOrderPatch.authorization.spec.ts` | **Neu** — 11 Tests |
| `src/lib/stores/boardstore/nostr/handlers/card.authorization.spec.ts` | **Neu** — 12 Tests |
| `docs/TO-FIX/TODO.md` | Tasks als erledigt markiert |

**Test Coverage (23 neue Tests)**

Column-Patch Guard (11 Tests):
- Owner-Patch akzeptiert
- Maintainer-Patch akzeptiert
- Fremder Pubkey verworfen
- Lokales Board ohne author → Guard übersprungen
- Leerer author-String → Guard übersprungen
- Fehlender event.pubkey → Guard übersprungen
- Zweiter Maintainer akzeptiert
- Deduplication intakt neben Guard
- Board-Mismatch greift weiterhin vor Guard
- Fallback wenn `isMaintainer` keine Funktion (plain object)
- Stranger rejected mit Fallback

Card Guard (12 Tests):
- Owner-Card-Update akzeptiert
- Maintainer-Card-Update akzeptiert
- Fremder Pubkey verworfen
- Lokales Board ohne author → Guard übersprungen
- Fehlender event.pubkey → Guard übersprungen
- Zweiter Maintainer akzeptiert
- Background-Board: Owner akzeptiert
- Background-Board: Maintainer akzeptiert
- Background-Board: Stranger rejected
- Background-Board ohne author → Guard übersprungen
- Background-Board lokal nicht vorhanden → Guard übersprungen, Event trotzdem gespeichert
- LWW-Skip funktioniert weiterhin neben Guard

**Verification**

```bash
pnpm run test:unit  # 38/38 Handler-Tests grün (inkl. 23 neue)
```
